### PR TITLE
Remove wrong highlight of string interpolation

### DIFF
--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -72,7 +72,6 @@ hi def link elixirBoolean                Boolean
 hi def link elixirVariable               Identifier
 hi def link elixirNumber                 Number
 hi def link elixirDocString              Comment
-hi def link elixirInterpolation          Delimiter
 hi def link elixirSymbolInterpolated     elixirSymbol
 hi def link elixirRegex                  elixirString
 hi def link elixirRegexEscape            elixirSpecial


### PR DESCRIPTION
This was causing the highlight to be of a delimiter to any element that did not have a highlight. Note that this does not mess up highlighting of the real string interpolation delimiters.

Before:
![screen shot 2013-05-27 at 09 51 35](https://f.cloud.github.com/assets/2074433/568088/54aebb74-c6cc-11e2-85b6-fd62d421ba9c.png)

After:
![screen shot 2013-05-27 at 09 52 14](https://f.cloud.github.com/assets/2074433/568094/76f33a5c-c6cc-11e2-8c54-6452a9602aba.png)
