### PR TITLE
Fix regex escape punctuation signs

### DIFF
--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -42,14 +42,14 @@ syn match elixirNumber '\<0[xX][0-9A-Fa-f]\+\>'
 syn match elixirNumber '\<0[bB][01]\+\>'
 
 syn match elixirRegexEscape            "\\\\\|\\[aAbBcdDefGhHnrsStvVwW]\|\\\d\{3}\|\\x[0-9a-fA-F]\{2}" contained
-syn match elixirRegexEscapePunctuation "?\|\.\|*\|\[\|\]\|+\|\^\|\$\||\|(\|)\|{\|}" contained
+syn match elixirRegexEscapePunctuation "?\|\\.\|*\|\\\[\|\\\]\|+\|\\^\|\\\$\|\\|\|\\(\|\\)\|\\{\|\\}" contained
 syn match elixirRegexQuantifier        "[*?+][?+]\=" contained display
 syn match elixirRegexQuantifier        "{\d\+\%(,\d*\)\=}?\=" contained display
 syn match elixirRegexCharClass         "\[:\(alnum\|alpha\|ascii\|blank\|cntrl\|digit\|graph\|lower\|print\|punct\|space\|upper\|word\|xdigit\):\]" contained display
 
 syn region elixirRegex matchgroup=elixirDelimiter start="%r/" end="/[uiomxfr]*" skip="\\\\" contains=@elixirRegexSpecial
 
-syn cluster elixirRegexSpecial   contains=elixirRegexEscape,elixirRegexCharClass,elixirRegexQuantifier
+syn cluster elixirRegexSpecial   contains=elixirRegexEscape,elixirRegexCharClass,elixirRegexQuantifier,elixirRegexEscapePunctuation
 syn cluster elixirStringContained contains=elixirInterpolation,elixirRegexEscape,elixirRegexCharClass
 
 syn region elixirString        matchgroup=elixirDelimiter start="'" end="'" skip="\\'"


### PR DESCRIPTION
Before:
![screen shot 2013-05-28 at 09 55 08](https://f.cloud.github.com/assets/2074433/572285/f793f24a-c795-11e2-91ea-67de1e86addc.png)
After:
![screen shot 2013-05-28 at 09 54 28](https://f.cloud.github.com/assets/2074433/572286/fb274ef2-c795-11e2-9054-0e96e5e5a36f.png)

Note a quantifier has the same highlight of their escaped version. However, this is caused by the highlighting that sets the same color for them.

As a side effect, this solves another issue with punctuation signs inside syntax regions such as `elixirInterpolation`.

Before:
![screen shot 2013-05-28 at 09 58 32](https://f.cloud.github.com/assets/2074433/572302/50e1dc18-c796-11e2-9941-5287c5a86b63.png)
After:
![screen shot 2013-05-28 at 09 59 16](https://f.cloud.github.com/assets/2074433/572307/697b1a3c-c796-11e2-8498-59266893d793.png)

Nice way to check syntax `echo map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")')` with the cursor on the thing you want to check.
