### PR TITLE
Elixir do .. end blocks and fn .. end anonymous functions

### DIFF
--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -10,6 +10,8 @@ endif
 " syncing starts 2000 lines before top line so docstrings don't screw things up
 syn sync minlines=2000
 
+syn cluster elixirNotTop contains=@elixirRegexSpecial,@elixirStringContained,elixirTodo
+
 syn match elixirComment '#.*' contains=elixirTodo
 syn keyword elixirTodo FIXME NOTE TODO OPTIMIZE XXX HACK contained
 
@@ -49,20 +51,20 @@ syn match elixirRegexCharClass         "\[:\(alnum\|alpha\|ascii\|blank\|cntrl\|
 
 syn region elixirRegex matchgroup=elixirDelimiter start="%r/" end="/[uiomxfr]*" skip="\\\\" contains=@elixirRegexSpecial
 
-syn cluster elixirRegexSpecial   contains=elixirRegexEscape,elixirRegexCharClass,elixirRegexQuantifier,elixirRegexEscapePunctuation
+syn cluster elixirRegexSpecial    contains=elixirRegexEscape,elixirRegexCharClass,elixirRegexQuantifier,elixirRegexEscapePunctuation
 syn cluster elixirStringContained contains=elixirInterpolation,elixirRegexEscape,elixirRegexCharClass
 
 syn region elixirString        matchgroup=elixirDelimiter start="'" end="'" skip="\\'"
 syn region elixirString        matchgroup=elixirDelimiter start='"' end='"' skip='\\"' contains=@elixirStringContained
-syn region elixirInterpolation matchgroup=elixirDelimiter start="#{" end="}" contained contains=ALLBUT,elixirComment
+syn region elixirInterpolation matchgroup=elixirDelimiter start="#{" end="}" contained contains=ALLBUT,elixirComment,@elixirNotTop
 syn region elixirDocString     start=+"""+ end=+"""+ contains=elixirTodo
 syn region elixirDocString     start=+'''+ end=+'''+ contains=elixirTodo
 
 syn match elixirSymbolInterpolated ':\("\)\@=' contains=elixirString
 syn match elixirString             "\(\w\)\@<!?\%(\\\(x\d{1,2}\|\h{1,2}\h\@!\>\|0[0-7]{0,2}[0-7]\@!\>\|[^x0MC]\)\|(\\[MC]-)+\w\|[^\s\\]\)"
 
-syn region elixirBlock              matchgroup=elixirKeyword start="\<do\>\(:\)\@!" end="\<end\>" contains=ALL fold
-syn region elixirAnonymousFunction  matchgroup=elixirKeyword start="\<fn\>" end="\<end\>" contains=ALL fold
+syn region elixirBlock              matchgroup=elixirKeyword start="\<do\>\(:\)\@!" end="\<end\>" contains=ALLBUT,@elixirNotTop fold
+syn region elixirAnonymousFunction  matchgroup=elixirKeyword start="\<fn\>"         end="\<end\>" contains=ALLBUT,@elixirNotTop fold
 
 hi def link elixirComment                Comment
 hi def link elixirTodo                   Todo


### PR DESCRIPTION
Defines concepts of a block and an anonymous function. This also allows folding.

The words `do`, `end` and `fn` had to be removed from `elixirKeyword` group because they are delimiters for blocks and functions. However when a block or an anonymous function is detected each delimiter is considered a `elixirKeyword`.
