### PR TITLE
Defs

### DIFF
--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -91,7 +91,7 @@ syn match  elixirFunctionDeclaration    "[^[:space:];#<,()\[\]]\+" contained    
 syn match  elixirProtocolDeclaration    "[^[:space:];#<]\+"        contained contains=elixirName                           skipwhite skipnl
 syn match  elixirImplDeclaration        "[^[:space:];#<]\+"        contained contains=elixirName                           skipwhite skipnl
 syn match  elixirRecordDeclaration      "[^[:space:];#<]\+"        contained contains=elixirName                           skipwhite skipnl
-syn match  elixirMacroDeclaration       "[^[:space:];#<,()\[\]]\+" contained                                               skipwhite skipnl
+syn match  elixirMacroDeclaration       "[^[:space:];#<,()\[\]]\+" contained                     nextgroup=elixirArguments skipwhite skipnl
 syn match  elixirDelegateDeclaration    "[^[:space:];#<,()\[\]]\+" contained contains=elixirFunctionDeclaration            skipwhite skipnl
 syn region elixirDelegateDeclaration    start='\['     end='\]'    contained contains=elixirFunctionDeclaration            skipwhite skipnl
 syn match  elixirOverridableDeclaration "[^[:space:];#<]\+"        contained contains=elixirName                           skipwhite skipnl
@@ -114,6 +114,7 @@ hi def link elixirOverridableDefine      Define
 hi def link elixirExceptionDefine        Define
 hi def link elixirCallbackDefine         Define
 hi def link elixirFunctionDeclaration    Function
+hi def link elixirMacroDeclaration       Macro
 hi def link elixirInclude                Include
 hi def link elixirComment                Comment
 hi def link elixirTodo                   Todo


### PR DESCRIPTION
More fixes for syntax highlight. Now,`def`, `defp`, `defmodule`, `defprotocol`, `defimpl`, `defrecord`, `defrecordp`, `defmacro`, `defmacrop`, `defdelegate`, `defoverridable`, `defcallback` and `defexception` are highlighted as `Define`. Also define concept of declaration for each for these defs.

![defs_example](https://f.cloud.github.com/assets/2074433/596963/1001a5cc-cbcc-11e2-9981-6419fca23401.png)

Much work in this PR. Some QA would really be appreciated. Just to remind, a good way of doing so is with this command

``` vim
echo map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")')
```
