### PR TITLE
Add ExUnit compiler

### DIFF
--- a/compiler/exunit.vim
+++ b/compiler/exunit.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Language:     ExUnit
 " Maintainer:   Rein Henrichs <rein.henrichs@gmail.com>
-" URL:          https://github.com/reinh/vim-elixir
+" URL:          https://github.com/elixir-lang/vim-elixir
 
 if exists("current_compiler")
   finish


### PR DESCRIPTION
Vim compilers (:h compilers) allow vim to run a compiler-like program
(:h 'makeprg'), parse errors in the output (:h 'errorformat'), and display
them in the QuickFix list (:h quickfix). This adds a compiler for ExUnit
that runs `mix test` and parses the output to display test failures. It
can be used as:

```
:compiler exunit
:make
```

TODO: Formatter currently only supports failures, not exceptions.
