### PR TITLE
Fix argument highlighting when using parentheses

### DIFF
--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -15,6 +15,7 @@ syn cluster elixirNotTop contains=@elixirRegexSpecial,@elixirStringContained,@el
 syn match elixirComment '#.*' contains=elixirTodo
 syn keyword elixirTodo FIXME NOTE TODO OPTIMIZE XXX HACK contained
 
+syn keyword elixirKeyword is_atom is_binary is_bitstring is_boolean is_float is_function is_integer is_list is_number is_pid is_port is_record is_reference is_tuple is_exception
 syn keyword elixirKeyword case cond bc lc inlist inbits if unless try receive function
 syn keyword elixirKeyword exit raise throw after rescue catch else
 syn keyword elixirKeyword use quote unquote super alias
@@ -68,7 +69,7 @@ syn match elixirString             "\(\w\)\@<!?\%(\\\(x\d{1,2}\|\h{1,2}\h\@!\>\|
 syn region elixirBlock              matchgroup=elixirKeyword start="\<do\>\(:\)\@!" end="\<end\>" contains=ALLBUT,@elixirNotTop fold
 syn region elixirAnonymousFunction  matchgroup=elixirKeyword start="\<fn\>"         end="\<end\>" contains=ALLBUT,@elixirNotTop fold
 
-syn region elixirArguments start="(" end=")" contained
+syn region elixirArguments start="(" end=")" contained contains=elixirOperator,elixirSymbol,elixirPseudoVariable,elixirName,elixirBoolean,elixirVariable,elixirNumber,elixirDocString,elixirSymbolInterpolated,elixirRegex,elixirRegexEscape,elixirRegexEscapePunctuation,elixirRegexCharClass,elixirRegexQuantifier,elixirSpecial,elixirString,elixirDelimiter
 
 " Defines
 syn keyword elixirDefine              def            nextgroup=elixirFunctionDeclaration    skipwhite skipnl


### PR DESCRIPTION
![before](http://cl.ly/image/0Q0Y051J2u2U/before.png) ![after](http://cl.ly/image/0B0P1Z0X3L1Q/after.png)

It also adds [type check](http://cl.ly/image/0Q0Y051J2u2U/before.png) functions as keywords
