### PR TITLE
Fix: heredocs syntax and tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ module Support
     content = write_file(string)
 
     @vim.edit file
-    @vim.feedkeys "/#{cursor}\n"
+    @vim.search cursor
 
     cursor_syntax_stack.should include(syntax)
   end
@@ -25,7 +25,7 @@ module Support
     content = write_file(string)
 
     @vim.edit file
-    @vim.normal "/#{cursor}\n"
+    @vim.search cursor
 
     cursor_syntax_stack.should_not include(type)
   end

--- a/spec/syntax/heredoc_spec.rb
+++ b/spec/syntax/heredoc_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe "Heredoc syntax" do
+  describe "binary" do
+    it "with multiline content" do
+      assert_correct_syntax 'elixirDocString', 'foo', <<-EOF
+        @doc """
+        foo
+        """
+      EOF
+    end
+
+    it "escapes quotes unless only preceded by whitespace" do
+      assert_correct_syntax 'elixirDocString', %q(^\s*\zs"""), <<-EOF
+        @doc """
+        foo """
+        """
+      EOF
+    end
+
+    it "does not include content on initial line", focus: true do
+      assert_correct_syntax 'elixirNumber', '0', <<-EOF
+        String.at """, 0
+        foo
+        end
+      EOF
+    end
+  end
+
+  describe "character list" do
+    it "with multiline content" do
+      assert_correct_syntax 'elixirDocString', 'foo', <<-EOF
+        @doc """
+        foo
+        """
+      EOF
+    end
+
+    it "escapes quotes unless only preceded by whitespace" do
+      assert_correct_syntax 'elixirDocString', %q(^\s*\zs'''), <<-EOF
+        @doc '''
+        foo '''
+        '''
+      EOF
+    end
+  end
+end

--- a/spec/syntax/sigil_spec.rb
+++ b/spec/syntax/sigil_spec.rb
@@ -72,7 +72,7 @@ describe "Sigil syntax" do
     end
 
     it "with escapes" do
-      assert_correct_syntax 'elixirRegexEscape', '\\\\', '%b(foo \n bar)'
+      assert_correct_syntax 'elixirRegexEscape', '\\', '%b(foo \n bar)'
     end
 
     it "with interpolation" do

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -60,8 +60,11 @@ syn cluster elixirStringContained contains=elixirInterpolation,elixirRegexEscape
 syn region elixirString        matchgroup=elixirDelimiter start="'" end="'" skip="\\'"
 syn region elixirString        matchgroup=elixirDelimiter start='"' end='"' skip='\\"' contains=@elixirStringContained
 syn region elixirInterpolation matchgroup=elixirDelimiter start="#{" end="}" contained contains=ALLBUT,elixirComment,@elixirNotTop
-syn region elixirDocString     start=+"""+ end=+"""+ contains=elixirTodo fold
-syn region elixirDocString     start=+'''+ end=+'''+ contains=elixirTodo fold
+
+syn region elixirDocStringStart matchgroup=elixirDocString start=+"""+ end=+$+ oneline contains=ALLBUT,@elixirNotTop
+syn region elixirDocStringStart matchgroup=elixirDocString start=+'''+ end=+$+ oneline contains=ALLBUT,@elixirNotTop
+syn region elixirDocString     start=+\z("""\)+ end=+^\s*\zs\z1+ contains=elixirDocStringStart,elixirTodo fold keepend
+syn region elixirDocString     start=+\z('''\)+ end=+^\s*\zs\z1+ contains=elixirDocStringStart,elixirTodo fold keepend
 
 syn match elixirSymbolInterpolated ':\("\)\@=' contains=elixirString
 syn match elixirString             "\(\w\)\@<!?\%(\\\(x\d{1,2}\|\h{1,2}\h\@!\>\|0[0-7]{0,2}[0-7]\@!\>\|[^x0MC]\)\|(\\[MC]-)+\w\|[^\s\\]\)"


### PR DESCRIPTION
This should fix #11, also improved `assert_correct_syntax` to use search
- escape quotes correctly
- don't include content on the first line
