### PR TITLE
Fix comment/string indentation and keyword blocks

### DIFF
--- a/indent/elixir.vim
+++ b/indent/elixir.vim
@@ -38,19 +38,20 @@ function! GetElixirIndent(...)
     return 0
   endif
 
-  if getline(lnum) =~ s:indent_keywords .
-        \ '\|^\s*\%(^.*[\[{(].*[,:]\|.*->\)$'
-    let ind += &sw
-  endif
+  if synIDattr(synID(v:lnum, 1, 1), "name") !~ '\(Comment\|String\)$'
+    if getline(lnum) =~ s:indent_keywords .
+          \ '\|^\s*\%(^.*[\[{(].*[,:]\|.*->\)$'
+      let ind += &sw
+    endif
 
-  if getline(v:lnum) =~ s:deindent_keywords
-    let bslnum = searchpair(
-          \ '\<\%(' . s:block_start . '\)\>',
-          \ '\<\%(' . s:block_middle . '\)\>\zs',
-          \ '[^:]\<' . s:block_end . '\>\zs',
-          \ 'nbW',
-          \ s:block_skip )
-    let ind = indent(bslnum)
+    if getline(v:lnum) =~ s:deindent_keywords
+      let bslnum = searchpair( '\<\%(' . s:block_start . '\):\@!\>',
+            \ '\<\%(' . s:block_middle . '\):\@!\>\zs',
+            \ '\<:\@<!' . s:block_end . '\>\zs',
+            \ 'nbW',
+            \ s:block_skip )
+      let ind = indent(bslnum)
+    endif
   endif
 
   return ind

--- a/spec/indent/blocks_spec.rb
+++ b/spec/indent/blocks_spec.rb
@@ -18,4 +18,12 @@ describe "Indenting" do
       end
     EOF
   end
+
+  it "does not consider do: as the start of a block" do
+    assert_correct_indenting <<-EOF
+      def f do
+        if true do: 42
+      end
+    EOF
+  end
 end

--- a/spec/indent/documentation_spec.rb
+++ b/spec/indent/documentation_spec.rb
@@ -5,9 +5,9 @@ describe "Indenting" do
     it "with end keyword" do
       assert_correct_indenting <<-EOF
         defmodule Test do
-          @doc ""
+          @doc """
           end
-          ""
+          """
         end
       EOF
     end


### PR DESCRIPTION
This fixes the last failing spec, also added a spec for the keyword blocks
