### PR TITLE
Show case indentation bug through a broken spec.

### DIFF
--- a/spec/indent/case_spec.rb
+++ b/spec/indent/case_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe "Indenting" do
+  specify "case statements" do
+    assert_correct_indenting <<-EOF
+      case some_function do
+        :ok ->
+          :ok
+        { :error, :message } ->
+          { :error, :message }
+      end
+    EOF
+  end
+end


### PR DESCRIPTION
As @jeregrine pointed out on #57, `case` indentation is broken.

As expected the build will be broken.
