### PR TITLE
Fix indentation specs

### DIFF
--- a/indent/elixir.vim
+++ b/indent/elixir.vim
@@ -10,7 +10,7 @@ let b:did_indent = 1
 
 setlocal nosmartindent
 
-setlocal indentexpr=GetElixirIndent(v:lnum)
+setlocal indentexpr=GetElixirIndent()
 setlocal indentkeys+==end,=else:,=match:,=elsif:,=catch:,=after:,=rescue:
 
 if exists("*GetElixirIndent")
@@ -31,7 +31,7 @@ let s:pipeline     = '^\s*|>.*$'
 let s:indent_keywords   = '\<\%(' . s:block_start . '\|' . s:block_middle . '\)$' . '\|' . s:arrow
 let s:deindent_keywords = '^\s*\<\%(' . s:block_end . '\|' . s:block_middle . '\)\>' . '\|' . s:arrow
 
-function! GetElixirIndent(...)
+function! GetElixirIndent()
   let lnum = prevnonblank(v:lnum - 1)
   let ind  = indent(lnum)
 
@@ -39,6 +39,14 @@ function! GetElixirIndent(...)
   if lnum == 0
     return 0
   endif
+
+  " TODO: Remove this 2 lines
+  " I don't know why, but for the test on spec/indent/lists_spec.rb:24.
+  " Vim is making some mess on parsing the syntax of 'end', it is being
+  " recognized as 'elixirString' when should be recognized as 'elixirBlock'.
+  " This forces vim to sync the syntax.
+  call synID(v:lnum, 1, 1)
+  syntax sync fromstart
 
   if synIDattr(synID(v:lnum, 1, 1), "name") !~ s:skip_syntax
     let current_line = getline(v:lnum)
@@ -61,7 +69,7 @@ function! GetElixirIndent(...)
     if current_line =~ s:pipeline &&
           \ last_line =~ '^[^=]\+=.\+$'
       let b:old_ind = ind
-      let ind += round(match(last_line, '=') / &sw) * &sw
+      let ind = float2nr(matchend(last_line, '=\s*[^ ]') / &sw) * &sw
     endif
 
     " if last line starts with pipeline
@@ -78,6 +86,7 @@ function! GetElixirIndent(...)
             \ '\<:\@<!' . s:block_end . '\>\zs',
             \ 'nbW',
             \ s:block_skip )
+
       let ind = indent(bslnum)
     endif
 

--- a/spec/indent/pipeline_spec.rb
+++ b/spec/indent/pipeline_spec.rb
@@ -42,4 +42,13 @@ describe "Indenting" do
     end
     EOF
   end
+
+  it "using a record with pipeline" do
+    assert_correct_indenting <<-EOF
+    defrecord RECORD, field_a: nil, field_b: nil
+
+    rec = RECORD.new
+          |> IO.inspect
+    EOF
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,9 @@ module Support
     content = write_file(string)
 
     @vim.edit file
+    # remove all indentation
+    @vim.normal 'ggVG999<<'
+    # force vim to indent the file
     @vim.normal 'gg=G'
     @vim.write
 


### PR DESCRIPTION
Remove all indentation before force vim to indent to check if vim indent will the code right.

This is important because sometimes vim keeps the indentation wrote and don't change with `gg=G`. So to verify if the vim it's really indenting the code it's important remove the wrote indentation before the expectation.

@carlosgaldino, @rafaelfranca could you give a look in this?
