### PR TITLE
Fix highlight error

### DIFF
--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -16,8 +16,8 @@ syn match elixirComment '#.*' contains=elixirTodo
 syn keyword elixirTodo FIXME NOTE TODO OPTIMIZE XXX HACK contained
 
 syn keyword elixirKeyword is_atom is_binary is_bitstring is_boolean is_float is_function is_integer is_list is_number is_pid is_port is_record is_reference is_tuple is_exception
-syn keyword elixirKeyword case cond bc lc inlist inbits if unless try receive function
-syn keyword elixirKeyword exit raise throw after rescue catch else
+syn keyword elixirKeyword case cond bc lc inlist inbits if unless try receive
+syn keyword elixirKeyword exit raise throw after rescue catch else do
 syn keyword elixirKeyword quote unquote super
 syn match   elixirKeyword '\<\%(->\)\>\s*'
 


### PR DESCRIPTION
add highliht of `do:`
remove highlight of `function`

preview is 

![preview](https://f.cloud.github.com/assets/3627395/2316912/b12768e2-a33f-11e3-8c30-8e2ae98a795c.png)

now is 

![now](https://f.cloud.github.com/assets/3627395/2316917/c16f6da8-a33f-11e3-8cd4-1e937164cc80.png)
