### PR TITLE
Fix: no highlight of `end`

### DIFF
--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -17,7 +17,7 @@ syn keyword elixirTodo FIXME NOTE TODO OPTIMIZE XXX HACK contained
 
 syn keyword elixirKeyword is_atom is_binary is_bitstring is_boolean is_float is_function is_integer is_list is_number is_pid is_port is_record is_reference is_tuple is_exception
 syn keyword elixirKeyword case cond bc lc inlist inbits if unless try receive
-syn keyword elixirKeyword exit raise throw after rescue catch else do
+syn keyword elixirKeyword exit raise throw after rescue catch else do end
 syn keyword elixirKeyword quote unquote super
 syn match   elixirKeyword '\<\%(->\)\>\s*'
 


### PR DESCRIPTION
Ok, I send a new issue here, just the same of [issue 69](https://github.com/elixir-lang/vim-elixir/pull/69)
