### PR TITLE
Fix string highlight inside list

### DIFF
--- a/spec/syntax/list_spec.rb
+++ b/spec/syntax/list_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe "List syntax" do
+  it 'should properly handle "\\\\" inside' do
+    syntax = <<-EOF
+      '"\\'
+      var = 1
+    EOF
+    syntax.should include_elixir_syntax('elixirId', 'var')
+    syntax.should_not include_elixir_syntax('elixirString', 'var')
+  end
+end

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -1,6 +1,6 @@
 " Vim syntax file
-" language: elixir
-" maintainer: carlos galdino <carloshsgaldino@gmail.com>
+" Language: Elixir
+" Maintainer: Carlos Galdino <carloshsgaldino@gmail.com>
 " Last Change: 2013 Apr 24
 
 if exists("b:current_syntax")


### PR DESCRIPTION
I'm not familiar with VimL, but this worked for me. Check plz it's not break something.

Example of wrong highlight https://github.com/devinus/poison/blob/master/lib/poison/encoder.ex#L87

or this:

``` elixir
'"\\'
var = 1
```
