### PR TITLE
Fix pipeline indentation bug when expression have multiple = symbols

### DIFF
--- a/indent/elixir.vim
+++ b/indent/elixir.vim
@@ -69,9 +69,16 @@ function! GetElixirIndent()
     endif
 
     " if line starts with pipeline
+    " and last line contains pipeline(s)
+    " align them
+    if last_line =~ '|>.*$' &&
+          \ current_line =~ s:pipeline
+      let ind = float2nr(match(last_line, '|>') / &sw) * &sw
+
+    " if line starts with pipeline
     " and last line is an attribution
     " indents pipeline in same level as attribution
-    if current_line =~ s:pipeline &&
+    elseif current_line =~ s:pipeline &&
           \ last_line =~ '^[^=]\+=.\+$'
       let b:old_ind = ind
       let ind = float2nr(matchend(last_line, '=\s*[^ ]') / &sw) * &sw

--- a/spec/indent/pipeline_spec.rb
+++ b/spec/indent/pipeline_spec.rb
@@ -32,6 +32,18 @@ describe "Indenting" do
     .should be_elixir_indentation
   end
 
+  it "do not breaks on `==`" do
+    <<-EOF
+    def test do
+      my_post = Post
+                |> where([p], p.id == 10)
+                |> where([p], u.user_id == 1)
+                |> select([p], p)
+    end
+    EOF
+    .should be_elixir_indentation
+  end
+
   it "pipeline operator with block open" do
     <<-EOF
     def test do


### PR DESCRIPTION
https://github.com/elixir-lang/vim-elixir/issues/93
