### PR TITLE
Correct indentation of anonymous functions (->)

### DIFF
--- a/indent/elixir.vim
+++ b/indent/elixir.vim
@@ -12,7 +12,6 @@ setlocal nosmartindent
 
 setlocal indentexpr=GetElixirIndent()
 setlocal indentkeys+=0=end,0=else,0=match,0=elsif,0=catch,0=after,0=rescue
-setlocal indentkeys+==->
 
 if exists("*GetElixirIndent")
   finish


### PR DESCRIPTION
As mentioned in #90, the `->` key combination triggers an indent with anonymous functions. With this PR it doesn't. I can't seem to find a reason to make `->` trigger indentation, and on my machine all tests pass.

Thanks!
