### PR TITLE
Allow for opening elixir files when using :Explore

### DIFF
--- a/ftdetect/elixir.vim
+++ b/ftdetect/elixir.vim
@@ -4,6 +4,9 @@ au BufRead,BufNewFile * call s:DetectElixir()
 
 au FileType elixir,eelixir setl sw=2 sts=2 et iskeyword+=!,?
 
+// fix for https://github.com/elixir-lang/vim-elixir/issues/121
+let g:filetype_euphoria = 'elixir'
+
 function! s:setf(filetype) abort
   let &filetype = a:filetype
 endfunction


### PR DESCRIPTION
This fixes:

- https://github.com/sheerun/vim-polyglot/issues/172
- https://github.com/elixir-lang/vim-elixir/issues/121

By setting variable used by native ftdetect of vim:

- https://github.com/vim/vim/blob/7a073549a3b1e72037a4e98ceb406d057ac9ba50/runtime/filetype.vim#L551-L563