### PR TITLE
syntax: match and/or/in/not as operators only if they are entire words

### DIFF
--- a/spec/syntax/operator_spec.rb
+++ b/spec/syntax/operator_spec.rb
@@ -22,4 +22,10 @@ describe 'Operators' do
       :queue.in x, 5
     EOF
   end
+
+  it 'does not highlight operators inside of elixirIds' do
+    expect(<<~EOF).not_to include_elixir_syntax('elixirOperator', 'in')
+      incoming
+    EOF
+  end
 end

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -36,7 +36,7 @@ syn keyword elixirSelf self
 " This unfortunately also matches function names in function calls
 syn match elixirUnusedVariable contained '\v%(^|[^.])@<=<_\w*>'
 
-syn match   elixirOperator '\v\.@<!%(and|or|in|not)'
+syn match   elixirOperator '\v\.@<!<%(and|or|in|not)>'
 syn match   elixirOperator '!==\|!=\|!'
 syn match   elixirOperator '=\~\|===\|==\|='
 syn match   elixirOperator '<<<\|<<\|<=\|<-\|<'


### PR DESCRIPTION
Fixes #364