### PR TITLE
Support interpolation in docstrings

### DIFF
--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -118,10 +118,10 @@ syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z('''\)+ end=
 " Documentation
 if exists('g:elixir_use_markdown_for_docs') && g:elixir_use_markdown_for_docs
   syn include @markdown syntax/markdown.vim
-  syn cluster elixirDocStringContained contains=@markdown,@Spell
+  syn cluster elixirDocStringContained contains=@markdown,@Spell,elixirInterpolation
 else
   let g:elixir_use_markdown_for_docs = 0
-  syn cluster elixirDocStringContained contains=elixirDocTest,elixirTodo,@Spell
+  syn cluster elixirDocStringContained contains=elixirDocTest,elixirTodo,@Spell,elixirInterpolation
 
   " doctests
   syn region elixirDocTest start="^\s*\%(iex\|\.\.\.\)\%((\d*)\)\?>\s" end="^\s*$" contained


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/1481027/30451064-bd5f7468-9960-11e7-8b6d-cf21e30e22f7.png)
After:
![after](https://user-images.githubusercontent.com/1481027/30451215-f6816828-9960-11e7-899d-5dd64d160e12.png)
