### PR TITLE
update docs to use correct repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ each plugin. In general, you have to add a line to your `~/.vimrc`:
 
 ```viml
 " vim-plug
-Plug 'elixir-lang/vim-elixir'
+Plug 'elixir-editors/vim-elixir'
 " NeoBundle
-NeoBundle 'elixir-lang/vim-elixir'
+NeoBundle 'elixir-editors/vim-elixir'
 " Vundle
-Plugin 'elixir-lang/vim-elixir'
+Plugin 'elixir-editors/vim-elixir'
 ```
 
 ### Manual installation


### PR DESCRIPTION
The current docs don't work. Updated repo location so that plugins actually get installed.