### PR TITLE
syntax: support interpolation in docstrings

### DIFF
--- a/spec/syntax/doc_spec.rb
+++ b/spec/syntax/doc_spec.rb
@@ -61,9 +61,9 @@ describe 'documentation syntax' do
         foo #{bar}
         """
       EOF
-      expect(ex).to     include_elixir_syntax('elixirDocString',       'foo')
-      expect(ex).to     include_elixir_syntax('elixirStringDelimiter', '"""')
-      expect(ex).not_to include_elixir_syntax('elixirInterpolation',   'bar')
+      expect(ex).to include_elixir_syntax('elixirDocString',       'foo')
+      expect(ex).to include_elixir_syntax('elixirStringDelimiter', '"""')
+      expect(ex).to include_elixir_syntax('elixirInterpolation',   'bar')
     end
 
     it 'doc with doctest' do

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -118,10 +118,10 @@ syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z('''\)+ end=
 " Documentation
 if exists('g:elixir_use_markdown_for_docs') && g:elixir_use_markdown_for_docs
   syn include @markdown syntax/markdown.vim
-  syn cluster elixirDocStringContained contains=@markdown,@Spell
+  syn cluster elixirDocStringContained contains=@markdown,@Spell,elixirInterpolation
 else
   let g:elixir_use_markdown_for_docs = 0
-  syn cluster elixirDocStringContained contains=elixirDocTest,elixirTodo,@Spell
+  syn cluster elixirDocStringContained contains=elixirDocTest,elixirTodo,@Spell,elixirInterpolation
 
   " doctests
   syn region elixirDocTest start="^\s*\%(iex\|\.\.\.\)\%((\d*)\)\?>\s" end="^\s*$" contained


### PR DESCRIPTION
I picked up the commit from #371 and changed the test that explicitly checked for _no_ interpolation before.

Closes https://github.com/elixir-editors/vim-elixir/pull/371.