### PR TITLE
Update manual_install.sh

### DIFF
--- a/manual_install.sh
+++ b/manual_install.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
 
-cp -R autoload/ ~/.vim/autoload/ &&
-    cp -R compiler/ ~/.vim/compiler/ &&
-    cp -R ftdetect/ ~/.vim/ftdetect/ &&
-    cp -R ftplugin/ ~/.vim/ftplugin/ &&
-    cp -R indent/ ~/.vim/indent/ &&
-    cp -R syntax/ ~/.vim/syntax/
+mkdir -p ~/.vim
+cp -R autoload/ compiler/ ftdetect/ ftplugin/ indent/ syntax/ ~/.vim/


### PR DESCRIPTION
In the previous version if ~/.vim exists and is already populated, directories would be copied incorrectly, resulting in something like ~/.vim/syntax/syntax/, ~/.vim/indent/indent, etc.