### PR TITLE
Do not set formatprg

### DIFF
--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -30,10 +30,6 @@ let &l:path =
 setlocal includeexpr=elixir#util#get_filename(v:fname)
 setlocal suffixesadd=.ex,.exs,.eex,.erl,.yrl,.hrl
 
-if empty(&formatprg)
-    setlocal formatprg=mix\ format\ -
-endif
-
 let &l:define = 'def\(macro\|guard\|delegate\)\=p\='
 
 silent! setlocal formatoptions-=t formatoptions+=croqlj


### PR DESCRIPTION
mix format only knows how to format a full file or module, so using it as formatprg will result in commands using `=` (and similar commands) with any text object that isn't a full module to format incorrectly, or throw a syntax error.

Removing it allows the user to have `=` and similar commands work with the default indenter for some of the file, while still being able to use `mix format` for the full file.

Fixes https://github.com/elixir-editors/vim-elixir/issues/401