### PR TITLE
Syntax: improve elixirExUnitMacro

### DIFF
--- a/spec/syntax/exunit_spec.rb
+++ b/spec/syntax/exunit_spec.rb
@@ -171,4 +171,15 @@ describe 'ExUnit syntax' do
     end
     EOF
   end
+
+  it 'does not highlight keys named after macros' do
+    expect('test: foo').not_to include_elixir_syntax('elixirExUnitMacro', 'test')
+  end
+
+  it 'does not highlight functions named after macros' do
+    # Tradeoff: Technically, a macro's argument can be put into parentheses, but
+    # that happens only seldomly. It's more likely that a function gets named
+    # after an ExUnit macro.
+    expect('setup(foo)').not_to include_elixir_syntax('elixirExUnitMacro', 'setup')
+  end
 end

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -160,7 +160,7 @@ syn match  elixirExceptionDeclaration   "[^[:space:];#<]\+"        contained con
 syn match  elixirCallbackDeclaration    "[^[:space:];#<,()\[\]]\+" contained contains=elixirFunctionDeclaration             skipwhite skipnl
 
 " ExUnit
-syn match  elixirExUnitMacro "\(^\s*\)\@<=\<\(test\|describe\|setup\|setup_all\|on_exit\|doctest\)\>"
+syn match  elixirExUnitMacro "\(^\s*\)\@<=\<\(test\|describe\|setup\|setup_all\|on_exit\|doctest\)\> "
 syn match  elixirExUnitAssert "\(^\s*\)\@<=\<\(assert\|assert_in_delta\|assert_raise\|assert_receive\|assert_received\|catch_error\)\>"
 syn match  elixirExUnitAssert "\(^\s*\)\@<=\<\(catch_exit\|catch_throw\|flunk\|refute\|refute_in_delta\|refute_receive\|refute_received\)\>"
 


### PR DESCRIPTION
Assumption: ExUnit macros are always followed by space.

Technically, a macro's argument can be put into parentheses, but that happens
only seldomly. It's more likely that a function gets named after an ExUnit
macro.

Fixes #418