### PR TITLE
manual_install: Safer copy to target directories

### DIFF
--- a/manual_install.sh
+++ b/manual_install.sh
@@ -1,7 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -eu
 
 for INSTALL_DIR in autoload compiler ftdetect ftplugin indent syntax
 do
   mkdir -p ~/.vim/${INSTALL_DIR}
-  cp -R ${INSTALL_DIR}/ ~/.vim/${INSTALL_DIR}
+  (set -x
+  cp -R ${INSTALL_DIR}/* ~/.vim/${INSTALL_DIR}/)
 done


### PR DESCRIPTION
I ran `./manual_install.sh` on my machine and ended up copying the directories into the target directories.

i.e. for `ftplugin` the `ftplugin` directory from this repo was copied into `~/.vim/ftplugin/` which resulted in this directory structure:

```bash
$ tree .vim/ftplugin                                                           
.vim/ftplugin                                                                                                                                                                                  
├── ftplugin                                                                                           
│   ├── eelixir.vim                                                                                    
│   └── elixir.vim                              
```

This PR fixed the issue for me at least.

Also: I changed the hashbang to be *bsd friendly since bash is not always installed in `/bin/`