### PR TITLE
Dockerfile and docker-compose setup for local testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:latest as base
+RUN useradd -m user
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt install -y bash bundler ruby-rspec xvfb
+RUN DEBIAN_FRONTEND=noninteractive apt install -y vim-gtk3
+RUN mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix
+
+FROM base as user
+USER user
+RUN bundle config path .bundler-path

--- a/README.md
+++ b/README.md
@@ -48,3 +48,12 @@ We've decided not to include `mix format` integration into `vim-elixir`. If you'
 
 Run the tests: `bundle exec parallel_rspec spec`
 Spawn a vim instance with dev configs: `bin/spawn_vim`
+
+Running the tests currently needs `gvim`. If you cannot install a version of vim to get the tests running,
+you can use `docker-compose` to spin up an enviroment for testing. Run
+
+```
+docker-compose run main
+```
+
+This will drop you into a shell where you can run the above commands. Run `docker-compose down` when you are done to free resources.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.4'
+services:
+  main:
+    container_name: vim_elixir
+    build:
+      context: .
+      target: user
+
+    volumes:
+      - ./:/home/user/vim-elixir
+      - tmp:/tmp
+
+    stdin_open: true
+    tty: true
+
+    environment:
+      - DISPLAY=:1.0
+    command: bash
+    working_dir: /home/user/vim-elixir
+    depends_on:
+      - xvfb
+
+  xvfb:
+    build:
+      context: .
+      target: user
+    volumes:
+      - tmp:/tmp
+    command: sh -c "rm -f /tmp/.X1-lock && Xvfb :1 -screen 0 800x600x16"
+
+volumes:
+  tmp:


### PR DESCRIPTION
Make local development more independent of the dev machine setup by providing a docker environment.

- [x] general cleanup
- [x] what about host UID != 1000? (works)
- [x] why does `rspec spec` work but `parallel_rspec spec` fails? (dunno, works now)
- [x] update README

Opening this PR early so more eyes can see this. Would this be a welcome addition to the project?