### PR TITLE
Fix syntax highlighting with "~S" sigil

### DIFF
--- a/spec/syntax/doc_spec.rb
+++ b/spec/syntax/doc_spec.rb
@@ -35,6 +35,17 @@ describe 'documentation syntax' do
       expect(ex).to include_elixir_syntax('elixirDocString', 'foo')
     end
 
+    it 'doc with sigil_S triple double-quoted multiline content with parentheses' do
+      ex = <<~'EOF'
+        @doc(~S"""
+        foo
+        """)
+      EOF
+      expect(ex).to include_elixir_syntax('elixirVariable', 'doc')
+      expect(ex).to include_elixir_syntax('elixirSigilDelimiter', 'S"""')
+      expect(ex).to include_elixir_syntax('elixirSigil', 'foo')
+    end
+
     it 'doc with sigil_S triple single-quoted multiline content' do
       ex = <<~'EOF'
         @doc ~S'''
@@ -44,6 +55,17 @@ describe 'documentation syntax' do
       expect(ex).to include_elixir_syntax('elixirVariable', 'doc')
       expect(ex).to include_elixir_syntax('elixirSigilDelimiter', "S'''")
       expect(ex).to include_elixir_syntax('elixirDocString', 'foo')
+    end
+
+    it 'doc with sigil_S triple single-quoted multiline content with parentheses' do
+      ex = <<~'EOF'
+        @doc(~S'''
+        foo
+        ''')
+      EOF
+      expect(ex).to include_elixir_syntax('elixirVariable', 'doc')
+      expect(ex).to include_elixir_syntax('elixirSigilDelimiter', "S'''")
+      expect(ex).to include_elixir_syntax('elixirSigil', 'foo')
     end
 
     it 'doc with triple single-quoted multiline content is not a doc string' do

--- a/spec/syntax/sigil_spec.rb
+++ b/spec/syntax/sigil_spec.rb
@@ -10,6 +10,20 @@ describe 'Sigil syntax' do
     expect('def f(~s(")), do: true').not_to include_elixir_syntax('elixirSigilDelimiter', '"')
   end
 
+  it 'as function argument multiline content' do
+    ex = <<~'EOF'
+      f(
+        ~S"""
+        foo
+        """,
+        bar
+      )
+    EOF
+
+    expect(ex).to include_elixir_syntax('elixirSigilDelimiter', 'S"""')
+    expect(ex).to include_elixir_syntax('elixirSigil', 'foo')
+  end
+
   describe 'upper case' do
     it 'string' do
       expect('~S(string)').to include_elixir_syntax('elixirSigilDelimiter', 'S')

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -103,8 +103,8 @@ syn region elixirSigil matchgroup=elixirSigilDelimiter start="\~\l("            
 syn region elixirSigil matchgroup=elixirSigilDelimiter start="\~\l\/"               end="\/"  skip="\\\\\|\\\/"  contains=@elixirStringContained,elixirRegexEscapePunctuation fold
 
 " Sigils surrounded with heredoc
-syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z("""\)+ end=+^\s*\zs\z1\s*$+ skip=+\\"+ fold
-syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z('''\)+ end=+^\s*\zs\z1\s*$+ skip=+\\'+ fold
+syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z("""\)+ end=+^\s*\z1+ skip=+\\"+ fold
+syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z('''\)+ end=+^\s*\z1+ skip=+\\'+ fold
 
 " Documentation
 if exists('g:elixir_use_markdown_for_docs') && g:elixir_use_markdown_for_docs


### PR DESCRIPTION
Fixes https://github.com/elixir-editors/vim-elixir/issues/438

Just changed to use the same pattern used in `elixirString`
https://github.com/elixir-editors/vim-elixir/blob/34873ee66e0dfd7c8105d6f0ad048a2df04e77f2/syntax/elixir.vim#L77

### Before
![image](https://user-images.githubusercontent.com/27698968/49900987-3deee680-fe47-11e8-8c0e-54df7e48c9e5.png)

![image](https://user-images.githubusercontent.com/27698968/49903399-3979fc00-fe4e-11e8-8289-5ea43c06c4be.png)

### After
![image](https://user-images.githubusercontent.com/27698968/49900957-29aae980-fe47-11e8-8c4c-4f4e7eb39f51.png)

![image](https://user-images.githubusercontent.com/27698968/49903439-5e6e6f00-fe4e-11e8-9574-1a8c53faf3e4.png)

