### PR TITLE
Add .xrl to the suffixes list

### DIFF
--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -28,7 +28,7 @@ let &l:path =
       \   &g:path
       \ ], ',')
 setlocal includeexpr=elixir#util#get_filename(v:fname)
-setlocal suffixesadd=.ex,.exs,.eex,.erl,.yrl,.hrl
+setlocal suffixesadd=.ex,.exs,.eex,.erl,.xrl,.yrl,.hrl
 
 let &l:define = 'def\(macro\|guard\|delegate\)\=p\='
 


### PR DESCRIPTION
This is the file extension used by [leex](http://erlang.org/doc/man/leex.html), Erlang's lexer generator.