### PR TITLE
Use 'set filetype' to set filetype once again

### DIFF
--- a/ftdetect/elixir.vim
+++ b/ftdetect/elixir.vim
@@ -1,13 +1,9 @@
-au BufRead,BufNewFile *.ex,*.exs call s:setf('elixir')
-au BufRead,BufNewFile *.eex call s:setf('eelixir')
+au BufRead,BufNewFile *.ex,*.exs set filetype=elixir
+au BufRead,BufNewFile *.eex set filetype=eelixir
 au BufRead,BufNewFile * call s:DetectElixir()
 
-function! s:setf(filetype) abort
-  let &filetype = a:filetype
-endfunction
-
 function! s:DetectElixir()
-  if getline(1) =~ '^#!.*\<elixir\>'
-    call s:setf('elixir')
+  if &filetype !=# 'elixir' && getline(1) =~# '^#!.*\<elixir\>'
+    set filetype=elixir
   endif
 endfunction


### PR DESCRIPTION
The `s:setf()` helper function was originally introduced to avoid setting the filetype multiple times (375e9e1). I believe this covered the case where a file had an `.ex` or `.exs` extension and also include "elixir" in the shebang line (such that `s:DetectElixir()` would match and call `set filetype` redundantly).

c56bd82 removed the existing `&filetype` check in `s:setf()`, relying on the `&filetype` global and ftdetect framework to avoid redundant updates.

I believe we can simplify this even further by using just `set filetype` in the file extension-based autocommands and including a guard against (re)setting filetype in `s:DetectElixir()`.

Also, use explicit case-insensitive comparison operators. This isn't a good place to make assumptions about `ignorecase`.