### PR TITLE
Syntax: Add doc delimiters

### DIFF
--- a/spec/syntax/doc_spec.rb
+++ b/spec/syntax/doc_spec.rb
@@ -5,11 +5,15 @@ require 'spec_helper'
 describe 'documentation syntax' do
   describe 'string' do
     it 'doc in double quotes' do
-      expect('@doc "foo"').to include_elixir_syntax('elixirDocString', 'foo')
+      ex = '@doc "foo"'
+      expect(ex).to include_elixir_syntax('elixirDocString', 'foo')
+      expect(ex).to include_elixir_syntax('elixirDocStringDelimiter', '"')
     end
 
     it 'doc in sigil_S' do
-      expect('@doc ~S(foo)').to include_elixir_syntax('elixirDocString', 'foo')
+      ex = '@doc ~S(foo)'
+      expect(ex).to include_elixir_syntax('elixirDocString', 'foo')
+      expect(ex).to include_elixir_syntax('elixirDocSigilDelimiter', 'S')
     end
   end
 
@@ -22,6 +26,7 @@ describe 'documentation syntax' do
       EOF
       expect(ex).to include_elixir_syntax('elixirVariable', 'doc')
       expect(ex).to include_elixir_syntax('elixirDocString', 'foo')
+      expect(ex).to include_elixir_syntax('elixirDocStringDelimiter', '"""')
     end
 
     it 'doc with sigil_S triple double-quoted multiline content' do
@@ -31,7 +36,7 @@ describe 'documentation syntax' do
         """
       EOF
       expect(ex).to include_elixir_syntax('elixirVariable', 'doc')
-      expect(ex).to include_elixir_syntax('elixirSigilDelimiter', 'S"""')
+      expect(ex).to include_elixir_syntax('elixirDocSigilDelimiter', 'S"""')
       expect(ex).to include_elixir_syntax('elixirDocString', 'foo')
     end
 
@@ -42,8 +47,8 @@ describe 'documentation syntax' do
         """)
       EOF
       expect(ex).to include_elixir_syntax('elixirVariable', 'doc')
-      expect(ex).to include_elixir_syntax('elixirSigilDelimiter', 'S"""')
-      expect(ex).to include_elixir_syntax('elixirSigil', 'foo')
+      expect(ex).to include_elixir_syntax('elixirDocSigilDelimiter', 'S"""')
+      expect(ex).to include_elixir_syntax('elixirDocString', 'foo')
     end
 
     it 'doc with sigil_S triple single-quoted multiline content' do
@@ -53,7 +58,7 @@ describe 'documentation syntax' do
         '''
       EOF
       expect(ex).to include_elixir_syntax('elixirVariable', 'doc')
-      expect(ex).to include_elixir_syntax('elixirSigilDelimiter', "S'''")
+      expect(ex).to include_elixir_syntax('elixirDocSigilDelimiter', "S'''")
       expect(ex).to include_elixir_syntax('elixirDocString', 'foo')
     end
 
@@ -64,8 +69,8 @@ describe 'documentation syntax' do
         ''')
       EOF
       expect(ex).to include_elixir_syntax('elixirVariable', 'doc')
-      expect(ex).to include_elixir_syntax('elixirSigilDelimiter', "S'''")
-      expect(ex).to include_elixir_syntax('elixirSigil', 'foo')
+      expect(ex).to include_elixir_syntax('elixirDocSigilDelimiter', "S'''")
+      expect(ex).to include_elixir_syntax('elixirDocString', 'foo')
     end
 
     it 'doc with triple single-quoted multiline content is not a doc string' do
@@ -83,9 +88,9 @@ describe 'documentation syntax' do
         foo #{bar}
         """
       EOF
-      expect(ex).to include_elixir_syntax('elixirDocString',       'foo')
-      expect(ex).to include_elixir_syntax('elixirStringDelimiter', '"""')
-      expect(ex).to include_elixir_syntax('elixirInterpolation',   'bar')
+      expect(ex).to include_elixir_syntax('elixirDocString', 'foo')
+      expect(ex).to include_elixir_syntax('elixirDocStringDelimiter', '"""')
+      expect(ex).to include_elixir_syntax('elixirInterpolation', 'bar')
     end
 
     it 'doc with doctest' do

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -117,15 +117,15 @@ else
   syn region elixirDocTest start="^\s*\%(iex\|\.\.\.\)\%((\d*)\)\?>\s" end="^\s*$" contained
 endif
 
-syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~[Ss]\z(/\|\"\|'\||\)" end="\z1" skip="\\\\\|\\\z1" contains=@elixirDocStringContained fold keepend
-syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~[Ss]{"                   end="}"   skip="\\\\\|\\}"   contains=@elixirDocStringContained fold keepend
-syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~[Ss]<"                   end=">"   skip="\\\\\|\\>"   contains=@elixirDocStringContained fold keepend
-syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~[Ss]\["                  end="\]"  skip="\\\\\|\\\]"  contains=@elixirDocStringContained fold keepend
-syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~[Ss]("                   end=")"   skip="\\\\\|\\)"   contains=@elixirDocStringContained fold keepend
-syn region elixirDocString matchgroup=elixirStringDelimiter start=+\%(@\w*doc\s\+\)\@<=\z("\)+                 end=+\z1+ skip=+\\\\\|\\\z1+  contains=@elixirDocStringContained keepend
-syn region elixirDocString matchgroup=elixirStringDelimiter start=+\%(@\w*doc\s\+\)\@<=\z("""\)+               end=+\z1+ contains=@elixirDocStringContained fold keepend
-syn region elixirDocString matchgroup=elixirSigilDelimiter  start=+\%(@\w*doc\s\+\)\@<=\~[Ss]\z('''\)+ end=+\z1+ skip=+\\'+ contains=@elixirDocStringContained fold keepend
-syn region elixirDocString matchgroup=elixirSigilDelimiter  start=+\%(@\w*doc\s\+\)\@<=\~[Ss]\z("""\)+ end=+\z1+ skip=+\\"+ contains=@elixirDocStringContained fold keepend
+syn region elixirDocString matchgroup=elixirDocSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~[Ss]\z(/\|\"\|'\||\)" end="\z1" skip="\\\\\|\\\z1" contains=@elixirDocStringContained fold keepend
+syn region elixirDocString matchgroup=elixirDocSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~[Ss]{"                   end="}"   skip="\\\\\|\\}"   contains=@elixirDocStringContained fold keepend
+syn region elixirDocString matchgroup=elixirDocSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~[Ss]<"                   end=">"   skip="\\\\\|\\>"   contains=@elixirDocStringContained fold keepend
+syn region elixirDocString matchgroup=elixirDocSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~[Ss]\["                  end="\]"  skip="\\\\\|\\\]"  contains=@elixirDocStringContained fold keepend
+syn region elixirDocString matchgroup=elixirDocSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~[Ss]("                   end=")"   skip="\\\\\|\\)"   contains=@elixirDocStringContained fold keepend
+syn region elixirDocString matchgroup=elixirDocStringDelimiter start=+\%(@\w*doc\s\+\)\@<=\z("\)+                 end=+\z1+ skip=+\\\\\|\\\z1+  contains=@elixirDocStringContained keepend
+syn region elixirDocString matchgroup=elixirDocStringDelimiter start=+\%(@\w*doc\s\+\)\@<=\z("""\)+               end=+\z1+ contains=@elixirDocStringContained fold keepend
+syn region elixirDocString matchgroup=elixirDocSigilDelimiter  start=+\%(@\w*doc\s\+\)\@<=\~[Ss]\z('''\)+ end=+\z1+ skip=+\\'+ contains=@elixirDocStringContained fold keepend
+syn region elixirDocString matchgroup=elixirDocSigilDelimiter  start=+\%(@\w*doc\s\+\)\@<=\~[Ss]\z("""\)+ end=+\z1+ skip=+\\"+ contains=@elixirDocStringContained fold keepend
 
 " Defines
 syn match elixirDefine              '\<def\>\(:\)\@!'             nextgroup=elixirFunctionDeclaration    skipwhite skipnl
@@ -209,6 +209,8 @@ hi def link elixirRegexQuantifier        elixirSpecial
 hi def link elixirSpecial                Special
 hi def link elixirString                 String
 hi def link elixirSigil                  String
+hi def link elixirDocStringDelimiter     elixirStringDelimiter
+hi def link elixirDocSigilDelimiter      elixirSigilDelimiter
 hi def link elixirStringDelimiter        Delimiter
 hi def link elixirRegexDelimiter         Delimiter
 hi def link elixirInterpolationDelimiter Delimiter


### PR DESCRIPTION
Why
---

I want to be able to differentiate between ordinary delimiters and those used for docs

How
---

* Add **elixirDocSigilDelimiter** group
* Add **elixirDocStringDelimiter** group
* Link **elixirDocStringDelimiter** and **elixirDocStringDelimiter** to **elixirStringDelimiter** and **elixirSigilDelimiter** to preserve existing behavior