### PR TITLE
Remove redundant 'formatoptions' setting

### DIFF
--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -47,7 +47,5 @@ onoremap <buffer> <silent> <expr> [[ ':silent keeppatterns ?'.b:block_begin.'<CR
 onoremap <buffer> <silent> <expr> ][ ':silent keeppatterns /'.b:block_end  .'<CR>'
 onoremap <buffer> <silent> <expr> [] ':silent keeppatterns ?'.b:block_end  .'<CR>'
 
-silent! setlocal formatoptions-=t formatoptions+=croqlj
-
-let b:undo_ftplugin = 'setlocal sw< sts< et< isk< com< cms< path< inex< sua< def<'.
+let b:undo_ftplugin = 'setlocal sw< sts< et< isk< com< cms< path< inex< sua< def< fo<'.
       \ '| unlet! b:match_ignorecase b:match_words b:block_begin b:block_end'


### PR DESCRIPTION
'formatoptions' is already set (to these same values) on line 35.

Also, add 'fo<' to the 'b:undo_ftplugin' list.