### PR TITLE
Use 'setfiletype' to set local &filetype

### DIFF
--- a/ftdetect/elixir.vim
+++ b/ftdetect/elixir.vim
@@ -1,9 +1,9 @@
-au BufRead,BufNewFile *.ex,*.exs set filetype=elixir
-au BufRead,BufNewFile *.eex set filetype=eelixir
+au BufRead,BufNewFile *.ex,*.exs setfiletype elixir
+au BufRead,BufNewFile *.eex setfiletype eelixir
 au BufRead,BufNewFile * call s:DetectElixir()
 
 function! s:DetectElixir()
   if &filetype !=# 'elixir' && getline(1) =~# '^#!.*\<elixir\>'
-    set filetype=elixir
+    setlocal filetype=elixir
   endif
 endfunction


### PR DESCRIPTION
'setfiletype' is nice in these cases because it prevents &filetype from
being set redundantly.

Note that the Vim runtime ships with a filetype match for *.ex (for
Euphoria), but our plugin-based filetype detection still gets the last
say.

Also, use 'setlocal' when setting &filetype in the shebang detection
path. We don't want to use 'setfiletype' here because it's possible we
need to override an existing syntax assignment, and we already guard
against setting &filetype to 'elixir' twice.