### PR TITLE
Fix wrong highlight of paren after `defmodule`

### DIFF
--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -146,7 +146,7 @@ syn match elixirCallbackDefine      '\<defcallback\>\(:\)\@!'     nextgroup=elix
 syn match elixirStructDefine        '\<defstruct\>\(:\)\@!'       skipwhite skipnl
 
 " Declarations
-syn match  elixirModuleDeclaration          "[^[:space:];#<]\+"        contained                      nextgroup=elixirBlock     skipwhite skipnl
+syn match  elixirModuleDeclaration          "[^[:space:];#<,()\[\]]\+" contained                      nextgroup=elixirBlock     skipwhite skipnl
 syn match  elixirFunctionDeclaration        "[^[:space:];#<,()\[\]]\+" contained                      nextgroup=elixirArguments skipwhite skipnl
 syn match  elixirPrivateFunctionDeclaration "[^[:space:];#<,()\[\]]\+" contained                      nextgroup=elixirArguments skipwhite skipnl
 syn match  elixirProtocolDeclaration        "[^[:space:];#<]\+"        contained contains=elixirAlias                           skipwhite skipnl


### PR DESCRIPTION
Added to `elixirModuleDeclaration` the exact same regex used in
`elixirFunctionDeclaration`.

![vim-elixir](https://user-images.githubusercontent.com/17637014/53449186-aa619680-39ef-11e9-972a-5b85c2edc6a3.png)

 Should fix #441 