### PR TITLE
Update README.md vim 8 install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Features:
 ```bash
 # vim 8 native package loading
 # http://vimhelp.appspot.com/repeat.txt.html#packages
-git clone https://github.com/elixir-lang/vim-elixir.git ~/.vim/pack/my-packages/start
+git clone https://github.com/elixir-lang/vim-elixir.git ~/.vim/pack/my-packages/start/vim-elixir
 ```
 
 ```bash


### PR DESCRIPTION
Vim 8 reads plugins from `~/.vim/pack/my-packages/start/pluginName`