### PR TITLE
Add LiveEEx template (.leex) syntax support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Features:
 
 * Syntax highlighting for Elixir and EEx files
-* Filetype detection for `.ex`, `.exs` and `.eex` files
+* Filetype detection for `.ex`, `.exs`, `.eex` and `.leex` files
 * Automatic indentation
 * Integration between Ecto projects and [vim-dadbod][] for running SQL queries
   on defined Ecto repositories

--- a/ftplugin/eelixir.vim
+++ b/ftplugin/eelixir.vim
@@ -20,7 +20,10 @@ if !exists("b:eelixir_subtype")
     let b:eelixir_subtype = matchstr(&filetype,'^eex\.\zs\w\+')
   endif
   if b:eelixir_subtype == ''
-    let b:eelixir_subtype = matchstr(substitute(expand("%:t"),'\c\%(\.eex\|\.eelixir\)\+$','',''),'\.\zs\w\+$')
+    let b:eelixir_subtype = matchstr(&filetype,'^leex\.\zs\w\+')
+  endif
+  if b:eelixir_subtype == ''
+    let b:eelixir_subtype = matchstr(substitute(expand("%:t"),'\c\%(\.eex\|\.leex\|\.eelixir\)\+$','',''),'\.\zs\w\+$')
   endif
   if b:eelixir_subtype == 'ex'
     let b:eelixir_subtype = 'elixir'

--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -28,7 +28,7 @@ let &l:path =
       \   &g:path
       \ ], ',')
 setlocal includeexpr=elixir#util#get_filename(v:fname)
-setlocal suffixesadd=.ex,.exs,.eex,.erl,.xrl,.yrl,.hrl
+setlocal suffixesadd=.ex,.exs,.eex,.leex,.erl,.xrl,.yrl,.hrl
 
 let &l:define = 'def\(macro\|guard\|delegate\)\=p\='
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -122,6 +122,12 @@ module EexBuffer
   end
 end
 
+module EexBuffer
+  def self.new
+    Buffer.new(VIM, :leex)
+  end
+end
+
 RSpec::Matchers.define :be_typed_with_right_indent do |syntax|
   buffer = Buffer.new(VIM, syntax || :ex)
 
@@ -145,6 +151,7 @@ end
 {
   be_elixir_indentation:  :ex,
   be_eelixir_indentation: :eex
+  be_eelixir_indentation: :leex
 }.each do |matcher, type|
   RSpec::Matchers.define matcher do
     buffer = Buffer.new(VIM, type)
@@ -170,6 +177,7 @@ end
 {
   include_elixir_syntax:  :ex,
   include_eelixir_syntax: :eex
+  include_eelixir_syntax: :leex
 }.each do |matcher, type|
   RSpec::Matchers.define matcher do |syntax, pattern|
     buffer = Buffer.new(VIM, type)

--- a/spec/syntax/sigil_spec.rb
+++ b/spec/syntax/sigil_spec.rb
@@ -87,6 +87,11 @@ describe 'Sigil syntax' do
     it 'without escaped parenthesis' do
       expect('~S(\( )').not_to include_elixir_syntax('elixirRegexEscapePunctuation', '( ')
     end
+
+    it 'Live EEx' do
+      expect('~L"""liveview template"""').to include_elixir_syntax('elixirSigilDelimiter', '""""')
+      expect('~L"""liveview template"""').to include_elixir_syntax('elixirSigilDelimiter', '""""')
+    end
   end
 
   describe 'lower case' do

--- a/syntax/eelixir.vim
+++ b/syntax/eelixir.vim
@@ -20,7 +20,10 @@ if !exists("b:eelixir_subtype")
     let b:eelixir_subtype = matchstr(&filetype,'^eex\.\zs\w\+')
   endif
   if b:eelixir_subtype == ''
-    let b:eelixir_subtype = matchstr(substitute(expand("%:t"),'\c\%(\.eex\|\.eelixir\)\+$','',''),'\.\zs\w\+$')
+    let b:eelixir_subtype = matchstr(&filetype,'^leex\.\zs\w\+')
+  endif
+  if b:eelixir_subtype == ''
+    let b:eelixir_subtype = matchstr(substitute(expand("%:t"),'\c\%(\.eex\|\.leex\|\.eelixir\)\+$','',''),'\.\zs\w\+$')
   endif
   if b:eelixir_subtype == 'ex'
     let b:eelixir_subtype = 'elixir'

--- a/syntax/eelixir.vim
+++ b/syntax/eelixir.vim
@@ -50,9 +50,6 @@ syn include @elixirTop syntax/elixir.vim
 
 syn cluster eelixirRegions contains=eelixirBlock,eelixirExpression,eelixirComment
 
-" Sigils surrounded with heredoc
-syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z("""\)+ end=+^\s*\z1+ skip=+\\"+ fold
-
 exe 'syn region  eelixirExpression matchgroup=eelixirDelimiter start="<%"  end="%\@<!%>" contains=@elixirTop  containedin=ALLBUT,@eelixirRegions keepend'
 exe 'syn region  eelixirExpression matchgroup=eelixirDelimiter start="<%=" end="%\@<!%>" contains=@elixirTop  containedin=ALLBUT,@eelixirRegions keepend'
 exe 'syn region  eelixirQuote      matchgroup=eelixirDelimiter start="<%%" end="%\@<!%>" contains=@elixirTop  containedin=ALLBUT,@eelixirRegions keepend'
@@ -60,10 +57,8 @@ exe 'syn region  eelixirComment    matchgroup=eelixirDelimiter start="<%#" end="
 
 " Define the default highlighting.
 
-hi def link eelixirDelimiter                  PreProc
-hi def link eelixirComment                    Comment
-hi def link elixirSigilDelimiter              Delimiter
-hi def link elixirDocSigilDelimiter           elixirSigilDelimiter
+hi def link eelixirDelimiter PreProc
+hi def link eelixirComment   Comment
 
 let b:current_syntax = 'eelixir'
 

--- a/syntax/eelixir.vim
+++ b/syntax/eelixir.vim
@@ -50,6 +50,9 @@ syn include @elixirTop syntax/elixir.vim
 
 syn cluster eelixirRegions contains=eelixirBlock,eelixirExpression,eelixirComment
 
+" Sigils surrounded with heredoc
+syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z("""\)+ end=+^\s*\z1+ skip=+\\"+ fold
+
 exe 'syn region  eelixirExpression matchgroup=eelixirDelimiter start="<%"  end="%\@<!%>" contains=@elixirTop  containedin=ALLBUT,@eelixirRegions keepend'
 exe 'syn region  eelixirExpression matchgroup=eelixirDelimiter start="<%=" end="%\@<!%>" contains=@elixirTop  containedin=ALLBUT,@eelixirRegions keepend'
 exe 'syn region  eelixirQuote      matchgroup=eelixirDelimiter start="<%%" end="%\@<!%>" contains=@elixirTop  containedin=ALLBUT,@eelixirRegions keepend'
@@ -57,8 +60,10 @@ exe 'syn region  eelixirComment    matchgroup=eelixirDelimiter start="<%#" end="
 
 " Define the default highlighting.
 
-hi def link eelixirDelimiter PreProc
-hi def link eelixirComment   Comment
+hi def link eelixirDelimiter                  PreProc
+hi def link eelixirComment                    Comment
+hi def link elixirSigilDelimiter              Delimiter
+hi def link elixirDocSigilDelimiter           elixirSigilDelimiter
 
 let b:current_syntax = 'eelixir'
 

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -105,6 +105,36 @@ syn region elixirSigil matchgroup=elixirSigilDelimiter start="\~\l\/"           
 syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z("""\)+ end=+^\s*\z1+ skip=+\\"+ fold
 syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z('''\)+ end=+^\s*\z1+ skip=+\\'+ fold
 
+" TODO
+" add LiveView Sigil Support within .ex
+function! TextEnableCodeSnip(filetype,start,end,textSnipHl) abort
+  let ft=toupper(a:filetype)
+  let group='textGroup'.ft
+  if exists('b:current_syntax')
+    let s:current_syntax=b:current_syntax
+    " Remove current syntax definition, as some syntax files (e.g. cpp.vim)
+    " do nothing if b:current_syntax is defined.
+    unlet b:current_syntax
+  endif
+  execute 'syntax include @'.group.' syntax/'.a:filetype.'.vim'
+  try
+    execute 'syntax include @'.group.' after/syntax/'.a:filetype.'.vim'
+  catch
+  endtry
+  if exists('s:current_syntax')
+    let b:current_syntax=s:current_syntax
+  else
+    unlet b:current_syntax
+  endif
+  execute 'syntax region textSnip'.ft.'
+  \ matchgroup='.a:textSnipHl.'
+  \ keepend
+  \ start="'.a:start.'" end="'.a:end.'"
+  \ contains=@'.group
+endfunction
+
+call TextEnableCodeSnip('html' ,'~L"""' ,'"""', 'SpecialComment')
+
 " Documentation
 if exists('g:elixir_use_markdown_for_docs') && g:elixir_use_markdown_for_docs
   syn include @markdown syntax/markdown.vim
@@ -221,6 +251,8 @@ hi def link elixirRegexDelimiter             Delimiter
 hi def link elixirInterpolationDelimiter     Delimiter
 hi def link elixirSigilDelimiter             Delimiter
 hi def link elixirPrivateRecordDeclaration   elixirRecordDeclaration
+" DOING
+" hi def link elixirLiveViewSigilDelimiter         elixirLiveViewSigilDelimiter
 
 let b:current_syntax = "elixir"
 


### PR DESCRIPTION
Add Phoenix LiveEEx Template (`.leex`) file type support.
Add LiveView sigil (`~L"""LiveView"""`) support.

Below is a comparison screenshot: 
<img width="2560" alt="compare_with_current" src="https://user-images.githubusercontent.com/20638592/54739840-920b2300-4c0d-11e9-9165-ca3375b2f79b.png">
