### PR TITLE
Add Phoenix LiveEEx Template (.leex) file type support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Features:
 
 * Syntax highlighting for Elixir and EEx files
-* Filetype detection for `.ex`, `.exs` and `.eex` files
+* Filetype detection for `.ex`, `.exs`, `.eex` and `.leex` files
 * Automatic indentation
 * Integration between Ecto projects and [vim-dadbod][] for running SQL queries
   on defined Ecto repositories

--- a/ftplugin/eelixir.vim
+++ b/ftplugin/eelixir.vim
@@ -20,7 +20,10 @@ if !exists("b:eelixir_subtype")
     let b:eelixir_subtype = matchstr(&filetype,'^eex\.\zs\w\+')
   endif
   if b:eelixir_subtype == ''
-    let b:eelixir_subtype = matchstr(substitute(expand("%:t"),'\c\%(\.eex\|\.eelixir\)\+$','',''),'\.\zs\w\+$')
+    let b:eelixir_subtype = matchstr(&filetype,'^leex\.\zs\w\+')
+  endif
+  if b:eelixir_subtype == ''
+    let b:eelixir_subtype = matchstr(substitute(expand("%:t"),'\c\%(\.eex\|\.leex\|\.eelixir\)\+$','',''),'\.\zs\w\+$')
   endif
   if b:eelixir_subtype == 'ex'
     let b:eelixir_subtype = 'elixir'

--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -28,7 +28,7 @@ let &l:path =
       \   &g:path
       \ ], ',')
 setlocal includeexpr=elixir#util#get_filename(v:fname)
-setlocal suffixesadd=.ex,.exs,.eex,.erl,.xrl,.yrl,.hrl
+setlocal suffixesadd=.ex,.exs,.eex,.leex,.erl,.xrl,.yrl,.hrl
 
 let &l:define = 'def\(macro\|guard\|delegate\)\=p\='
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -122,6 +122,12 @@ module EexBuffer
   end
 end
 
+module EexBuffer
+  def self.new
+    Buffer.new(VIM, :leex)
+  end
+end
+
 RSpec::Matchers.define :be_typed_with_right_indent do |syntax|
   buffer = Buffer.new(VIM, syntax || :ex)
 
@@ -145,6 +151,7 @@ end
 {
   be_elixir_indentation:  :ex,
   be_eelixir_indentation: :eex
+  be_eelixir_indentation: :leex
 }.each do |matcher, type|
   RSpec::Matchers.define matcher do
     buffer = Buffer.new(VIM, type)
@@ -170,6 +177,7 @@ end
 {
   include_elixir_syntax:  :ex,
   include_eelixir_syntax: :eex
+  include_eelixir_syntax: :leex
 }.each do |matcher, type|
   RSpec::Matchers.define matcher do |syntax, pattern|
     buffer = Buffer.new(VIM, type)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -151,7 +151,7 @@ end
 {
   be_elixir_indentation:  :ex,
   be_eelixir_indentation: :eex
-  be_eelixir_indentation: :leex
+  be_leelixir_indentation: :leex
 }.each do |matcher, type|
   RSpec::Matchers.define matcher do
     buffer = Buffer.new(VIM, type)
@@ -177,7 +177,7 @@ end
 {
   include_elixir_syntax:  :ex,
   include_eelixir_syntax: :eex
-  include_eelixir_syntax: :leex
+  include_leelixir_syntax: :leex
 }.each do |matcher, type|
   RSpec::Matchers.define matcher do |syntax, pattern|
     buffer = Buffer.new(VIM, type)

--- a/spec/syntax/sigil_spec.rb
+++ b/spec/syntax/sigil_spec.rb
@@ -87,6 +87,11 @@ describe 'Sigil syntax' do
     it 'without escaped parenthesis' do
       expect('~S(\( )').not_to include_elixir_syntax('elixirRegexEscapePunctuation', '( ')
     end
+
+    it 'Live EEx' do
+      expect('~L"""liveview template"""').to include_elixir_syntax('elixirSigilDelimiter', '""""')
+      expect('~L"""liveview template"""').to include_elixir_syntax('elixirSigilDelimiter', '""""')
+    end
   end
 
   describe 'lower case' do

--- a/spec/syntax/sigil_spec.rb
+++ b/spec/syntax/sigil_spec.rb
@@ -90,7 +90,6 @@ describe 'Sigil syntax' do
 
     it 'Live EEx' do
       expect('~L"""liveview template"""').to include_elixir_syntax('elixirSigilDelimiter', '""""')
-      expect('~L"""liveview template"""').to include_elixir_syntax('elixirSigilDelimiter', '""""')
     end
   end
 

--- a/syntax/eelixir.vim
+++ b/syntax/eelixir.vim
@@ -20,7 +20,10 @@ if !exists("b:eelixir_subtype")
     let b:eelixir_subtype = matchstr(&filetype,'^eex\.\zs\w\+')
   endif
   if b:eelixir_subtype == ''
-    let b:eelixir_subtype = matchstr(substitute(expand("%:t"),'\c\%(\.eex\|\.eelixir\)\+$','',''),'\.\zs\w\+$')
+    let b:eelixir_subtype = matchstr(&filetype,'^leex\.\zs\w\+')
+  endif
+  if b:eelixir_subtype == ''
+    let b:eelixir_subtype = matchstr(substitute(expand("%:t"),'\c\%(\.eex\|\.leex\|\.eelixir\)\+$','',''),'\.\zs\w\+$')
   endif
   if b:eelixir_subtype == 'ex'
     let b:eelixir_subtype = 'elixir'

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -105,6 +105,12 @@ syn region elixirSigil matchgroup=elixirSigilDelimiter start="\~\l\/"           
 syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z("""\)+ end=+^\s*\z1+ skip=+\\"+ fold
 syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z('''\)+ end=+^\s*\z1+ skip=+\\'+ fold
 
+
+" LiveView Sigils surrounded with ~L"""
+syntax include @HTML syntax/html.vim
+syntax region elixirLiveViewSigil matchgroup=elixirSigilDelimiter keepend start=+\~L\z("""\)+ end=+^\s*\z1+ skip=+\\"+ contains=@HTML fold
+
+
 " Documentation
 if exists('g:elixir_use_markdown_for_docs') && g:elixir_use_markdown_for_docs
   syn include @markdown syntax/markdown.vim


### PR DESCRIPTION
@jbodah  I closed the original #484 , please check this new pull quest, thank you.

Add Phoenix LiveEEx Template (`.leex`) file syntax highlight support.
Add LiveView sigil (~L"""LiveView""") syntax highlight support in `.ex` file.
Update README.md

Screen shot of `.leex` syntax highlight:

<img width="2560" alt="Screen Shot 2019-03-22 at 4 43 05 pm" src="https://user-images.githubusercontent.com/20638592/54803029-ea9bf800-4cc1-11e9-9198-6def57d13043.png">

Screen shot of LiveView sigil syntax highlight in `.ex`:

<img width="2560" alt="Screen Shot 2019-03-22 at 4 44 57 pm" src="https://user-images.githubusercontent.com/20638592/54803035-ed96e880-4cc1-11e9-8ee3-205751b5d07e.png">
