### PR TITLE
ftdetect: Fix detection when reopening

### DIFF
--- a/ftdetect/elixir.vim
+++ b/ftdetect/elixir.vim
@@ -3,7 +3,7 @@ au BufRead,BufNewFile *.eex,*.leex set filetype=eelixir
 au BufRead,BufNewFile * call s:DetectElixir()
 
 function! s:DetectElixir()
-  if &filetype !=# 'elixir' && getline(1) =~# '^#!.*\<elixir\>'
+  if (!did_filetype() || &filetype !=# 'elixir') && getline(1) =~# '^#!.*\<elixir\>'
     set filetype=elixir
   endif
 endfunction


### PR DESCRIPTION
When doing :e in an already opened elixir script lacking the .exs filename suffix, we would skip the check and end up with filetype=conf or something like that.
    
Fix this by forcing the check when `!did_filetype()` even if `&filetype ==# 'elixir'`.