### PR TITLE
syntax: Two alias-related fixes

### DIFF
--- a/spec/syntax/alias_spec.rb
+++ b/spec/syntax/alias_spec.rb
@@ -4,9 +4,10 @@ require 'spec_helper'
 
 describe 'Alias syntax' do
   it 'colorize only module alias' do
-    expect(<<~EOF).to include_elixir_syntax('elixirAlias', 'Enum')
-      Enum.empty?(...)
-    EOF
+    str = "Enum.empty?(...)"
+    expect(str).to include_elixir_syntax('elixirAlias', 'Enum')
+    expect(str).to include_elixir_syntax('elixirOperator', '\.')
+    expect(str).to include_elixir_syntax('elixirId', 'empty?')
   end
 
   it 'colorize the module alias even if it starts with `!`' do
@@ -32,5 +33,16 @@ describe 'Alias syntax' do
     expect(str).to include_elixir_syntax('elixirAlias', 'S')
     expect(str).to include_elixir_syntax('elixirAlias', '3')
     expect(str).to include_elixir_syntax('elixirAlias', 'Manager')
+  end
+
+  it 'colorize dots in module alias' do
+    str = "Foo.Bar.Baz.fun(...)"
+    expect(str).to include_elixir_syntax('elixirAlias', 'Foo')
+    expect(str).to include_elixir_syntax('elixirAlias', '\.\(Bar\)\@=')
+    expect(str).to include_elixir_syntax('elixirAlias', 'Bar')
+    expect(str).to include_elixir_syntax('elixirAlias', '\.\(Baz\)\@=')
+    expect(str).to include_elixir_syntax('elixirAlias', 'Baz')
+    expect(str).to include_elixir_syntax('elixirOperator', '\.\(fun\)\@=')
+    expect(str).to include_elixir_syntax('elixirId', 'fun')
   end
 end

--- a/spec/syntax/atom_spec.rb
+++ b/spec/syntax/atom_spec.rb
@@ -74,4 +74,18 @@ describe 'Atom syntax' do
     end
     EOF
   end
+
+  it '`Atom:` style atoms used in keyword list' do
+    expect(<<~EOF).to include_elixir_syntax('elixirAtom', 'Protocols:')
+    def project do
+      [
+        docs: [
+          groups_for_modules: [
+            Protocols: [Enumerable],
+          ]
+        ]
+      ]
+    end
+    EOF
+  end
 end

--- a/spec/syntax/defmodule_spec.rb
+++ b/spec/syntax/defmodule_spec.rb
@@ -10,9 +10,10 @@ describe 'Defmodule syntax' do
   end
 
   it 'defines module name as elixirModuleDeclaration' do
-    expect(<<~EOF).to include_elixir_syntax('elixirModuleDeclaration', 'HelloPhoenix.HelloController')
-      defmodule HelloPhoenix.HelloController do
-    EOF
+    str = "defmodule HelloPhoenix.HelloController do"
+    expect(str).to include_elixir_syntax('elixirModuleDeclaration', 'HelloPhoenix')
+    expect(str).to include_elixir_syntax('elixirModuleDeclaration', '\.')
+    expect(str).to include_elixir_syntax('elixirModuleDeclaration', 'HelloController')
   end
 
   it 'does not define module name as elixirAlias' do

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -39,7 +39,7 @@ syn match   elixirOperator '\.\.\|\.'
 syn match   elixirOperator "\^\^\^\|\^"
 syn match   elixirOperator '\\\\\|::\|\*\|/\|\~\~\~\|@'
 
-syn match   elixirAlias '\([a-z]\)\@<![A-Z]\w*'
+syn match   elixirAlias '\([a-z]\)\@<![A-Z]\w*\%(\.[A-Z]\w*\)*'
 
 syn match   elixirAtom '\(:\)\@<!:\%([a-zA-Z_]\w*\%([?!]\|=[>=]\@!\)\?\|<>\|===\?\|>=\?\|<=\?\)'
 syn match   elixirAtom '\(:\)\@<!:\%(<=>\|&&\?\|%\(()\|\[\]\|{}\)\|++\?\|--\?\|||\?\|!\|//\|[%&`/|]\)'

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -39,11 +39,11 @@ syn match   elixirOperator '\.\.\|\.'
 syn match   elixirOperator "\^\^\^\|\^"
 syn match   elixirOperator '\\\\\|::\|\*\|/\|\~\~\~\|@'
 
+syn match   elixirAlias '\([a-z]\)\@<![A-Z]\w*'
+
 syn match   elixirAtom '\(:\)\@<!:\%([a-zA-Z_]\w*\%([?!]\|=[>=]\@!\)\?\|<>\|===\?\|>=\?\|<=\?\)'
 syn match   elixirAtom '\(:\)\@<!:\%(<=>\|&&\?\|%\(()\|\[\]\|{}\)\|++\?\|--\?\|||\?\|!\|//\|[%&`/|]\)'
 syn match   elixirAtom "\%([a-zA-Z_]\w*[?!]\?\):\(:\)\@!"
-
-syn match   elixirAlias '\([a-z]\)\@<![A-Z]\w*'
 
 syn keyword elixirBoolean true false nil
 


### PR DESCRIPTION
* highlight dots in `Foo.Bar.fun` the same as in `defmodule Foo.Bar`
* highlight uppercased atoms in keyword lists (`[ Atom: 1 ]`) as atoms