### PR TITLE
syntax: Prevent syntax/{html,javascript}.vim from overriding our syn sync

### DIFF
--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -8,9 +8,6 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
-" syncing starts 2000 lines before top line so docstrings don't screw things up
-syn sync minlines=2000
-
 syn cluster elixirNotTop contains=@elixirRegexSpecial,@elixirStringContained,@elixirDeclaration,elixirTodo,elixirArguments,elixirBlockDefinition,elixirUnusedVariable,elixirStructDelimiter
 syn cluster elixirRegexSpecial contains=elixirRegexEscape,elixirRegexCharClass,elixirRegexQuantifier,elixirRegexEscapePunctuation
 syn cluster elixirStringContained contains=elixirInterpolation,elixirRegexEscape,elixirRegexCharClass
@@ -174,6 +171,9 @@ syn match  elixirCallbackDeclaration        "[^[:space:];#<,()\[\]]\+" contained
 syn match  elixirExUnitMacro "\(^\s*\)\@<=\<\(test\|describe\|setup\|setup_all\|on_exit\|doctest\)\>"
 syn match  elixirExUnitAssert "\(^\s*\)\@<=\<\(assert\|assert_in_delta\|assert_raise\|assert_receive\|assert_received\|catch_error\)\>"
 syn match  elixirExUnitAssert "\(^\s*\)\@<=\<\(catch_exit\|catch_throw\|flunk\|refute\|refute_in_delta\|refute_receive\|refute_received\)\>"
+
+" syncing starts 2000 lines before top line so docstrings don't screw things up
+syn sync minlines=2000
 
 hi def link elixirBlockDefinition            Define
 hi def link elixirDefine                     Define

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -1,5 +1,8 @@
-if exists("b:current_syntax")
-  finish
+if !exists("main_syntax")
+  if exists("b:current_syntax")
+    finish
+  endif
+  let main_syntax = "elixir"
 endif
 
 let s:cpo_save = &cpo
@@ -229,6 +232,10 @@ hi def link elixirSigilDelimiter             Delimiter
 hi def link elixirPrivateRecordDeclaration   elixirRecordDeclaration
 
 let b:current_syntax = "elixir"
+
+if main_syntax == "elixir"
+  unlet main_syntax
+endif
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -108,12 +108,14 @@ syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z('''\)+ end=
 
 " LiveView Sigils surrounded with ~L"""
 syntax include @HTML syntax/html.vim
+unlet b:current_syntax
 syntax region elixirLiveViewSigil matchgroup=elixirSigilDelimiter keepend start=+\~L\z("""\)+ end=+^\s*\z1+ skip=+\\"+ contains=@HTML fold
 
 
 " Documentation
 if exists('g:elixir_use_markdown_for_docs') && g:elixir_use_markdown_for_docs
   syn include @markdown syntax/markdown.vim
+  unlet b:current_syntax
   syn cluster elixirDocStringContained contains=@markdown,@Spell,elixirInterpolation
 else
   let g:elixir_use_markdown_for_docs = 0


### PR DESCRIPTION
When including other syntax types it's necessary to declare that we're
the main syntax, otherwise they will apply their own syn sync settings.

Here, by including html.vim in 7e00da6033b7847c6bb71df18f852342946eab42,
we end up with syn sync minlines=10 maxlines=100 and we sync using
html.vim syncing rules, which isn't at all what we want. Try opening
large_file.ex in the middle, syntax will be incorrect.

Unfortunately the main_syntax trick doesn't prevent javascript.vim from
doing syn sync fromstart. This is most likely a bug in javascript.vim
and I'll submit a pull request to vim to fix this. Luckily setting
main_syntax does prevent javascript.vim from introducing its own syncing
rules, it just overrides minlines and maxlines, so we can work around it
by moving the syn sync minlines to the end.