### PR TITLE
Set mix.lock as Elixir

### DIFF
--- a/ftdetect/elixir.vim
+++ b/ftdetect/elixir.vim
@@ -1,5 +1,6 @@
 au BufRead,BufNewFile *.ex,*.exs set filetype=elixir
 au BufRead,BufNewFile *.eex,*.leex set filetype=eelixir
+au BufRead,BufNewFile mix.lock set filetype=elixir
 au BufRead,BufNewFile * call s:DetectElixir()
 
 function! s:DetectElixir()


### PR DESCRIPTION
This explicitly sets `mix.lock` as an Elixir file. Otherwise, the file loads with no detected file format.