### PR TITLE
Do not change &formatprg globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Run [./manual_install.sh](manual_install.sh) to copy the contents of each direct
 We've decided not to include `mix format` integration into `vim-elixir`. If you'd like to set it up yourself, you have the following options:
 
 * For asynchronous execution of the formatter, have a look at [vim-mix-format](https://github.com/mhinz/vim-mix-format)
-* Add it as a `formatprg` (e.g. `set formatprg=mix\ format\ -`)
+* Add it as a `formatprg` (e.g. `setlocal formatprg=mix\ format\ -`)
 
 ## Development
 


### PR DESCRIPTION
Since `&formatprg` is "global or local to buffer", `:set` does not only change &formatprg of the current buffer, but also any other buffers. Prefer `:setlocal` instead.

```
:h formatprg
						*'formatprg'* *'fp'*
'formatprg' 'fp'	string (default "")
			global or local to buffer |global-local|
	The name of an external program that will be used to format the lines
	selected with the |gq| operator.  The program must take the input on
	stdin and produce the output on stdout.  The Unix program "fmt" is
	such a program.
	If the 'formatexpr' option is not empty it will be used instead.
	Otherwise, if 'formatprg' option is an empty string, the internal
	format function will be used |C-indenting|.
	Environment variables are expanded |:set_env|.  See |option-backslash|
	about including spaces and backslashes.
	This option cannot be set from a |modeline| or in the |sandbox|, for
	security reasons.
```