### PR TITLE
Add syntax highlight to function calls

### DIFF
--- a/spec/syntax/function_spec.rb
+++ b/spec/syntax/function_spec.rb
@@ -48,13 +48,25 @@ describe 'function syntax' do
     EOF
   end
 
+  it 'detects function calls appended by atom with parenthesis' do
+    expect(<<~'EOF').to include_elixir_syntax('elixirFunctionCall', 'func')
+      :mod.func()
+    EOF
+  end
+
   it 'detects function calls appended by module without parenthesis' do
     expect(<<~'EOF').to include_elixir_syntax('elixirFunctionCall', 'func')
       Mod.func
     EOF
   end
 
-  it 'does not highlight terms without a parentheresis' do
+  it 'detects function calls appended by atom without parenthesis' do
+    expect(<<~'EOF').to include_elixir_syntax('elixirFunctionCall', 'func')
+      :mod.func
+    EOF
+  end
+
+  it 'does not highlight function calls without parameters that have no parenthesis' do
     expect(<<~'EOF').not_to include_elixir_syntax('elixirFunctionCall', 'func')
       func
     EOF

--- a/spec/syntax/function_spec.rb
+++ b/spec/syntax/function_spec.rb
@@ -18,15 +18,57 @@ describe 'function syntax' do
     EOF
   end
 
+  it 'detects higher order function calls' do
+    expect(<<~'EOF').to include_elixir_syntax('elixirFunctionCall', 'func')
+      func.()
+    EOF
+  end
+
   it 'detects function calls with parenthesis' do
     expect(<<~'EOF').to include_elixir_syntax('elixirFunctionCall', 'func')
       func()
     EOF
   end
 
+  it 'detects function calls with bangs' do
+    expect(<<~'EOF').to include_elixir_syntax('elixirFunctionCall', 'func!')
+      func!()
+    EOF
+  end
+
+  it 'detects function calls with question marks' do
+    expect(<<~'EOF').to include_elixir_syntax('elixirFunctionCall', 'func?')
+      func?()
+    EOF
+  end
+
+  it 'detects function calls appended by module with parenthesis' do
+    expect(<<~'EOF').to include_elixir_syntax('elixirFunctionCall', 'func')
+      Mod.func()
+    EOF
+  end
+
   it 'detects function calls appended by module without parenthesis' do
     expect(<<~'EOF').to include_elixir_syntax('elixirFunctionCall', 'func')
       Mod.func
+    EOF
+  end
+
+  it 'does not highlight terms without a parentheresis' do
+    expect(<<~'EOF').not_to include_elixir_syntax('elixirFunctionCall', 'func')
+      func
+    EOF
+  end
+
+  it 'does not detect calls to function with invalid names' do
+    expect(<<~'EOF').not_to include_elixir_syntax('elixirFunctionCall', '2fast2func')
+      2fast2func()
+    EOF
+  end
+
+  it 'ignores spacing between module and function names' do
+    expect(<<~'EOF').not_to include_elixir_syntax('elixirFunctionCall', 'func')
+      Module .           func
     EOF
   end
 end

--- a/spec/syntax/function_spec.rb
+++ b/spec/syntax/function_spec.rb
@@ -66,7 +66,25 @@ describe 'function syntax' do
     EOF
   end
 
-  it 'does not highlight function calls without parameters that have no parenthesis' do
+  it 'detects function calls without parenthesis that contain paramenters' do
+    expect(<<~'EOF').to include_elixir_syntax('elixirFunctionCall', 'func')
+      func 1
+    EOF
+    expect(<<~'EOF').to include_elixir_syntax('elixirFunctionCall', 'func')
+      func [1]
+    EOF
+    expect(<<~'EOF').to include_elixir_syntax('elixirFunctionCall', 'func')
+      func :atom
+    EOF
+    expect(<<~'EOF').to include_elixir_syntax('elixirFunctionCall', 'func')
+      func "string"
+    EOF
+    expect(<<~'EOF').to include_elixir_syntax('elixirFunctionCall', 'func')
+      func 'a'
+    EOF
+  end
+
+  it 'does not highlight function calls without parenthesis that does not contain paramenters' do
     expect(<<~'EOF').not_to include_elixir_syntax('elixirFunctionCall', 'func')
       func
     EOF

--- a/spec/syntax/function_spec.rb
+++ b/spec/syntax/function_spec.rb
@@ -17,4 +17,16 @@ describe 'function syntax' do
         __ensure_defimpl__(protocol, for, env)
     EOF
   end
+
+  it 'detects function calls with parenthesis' do
+    expect(<<~'EOF').to include_elixir_syntax('elixirFunctionCall', 'func')
+      func()
+    EOF
+  end
+
+  it 'detects function calls appended by module without parenthesis' do
+    expect(<<~'EOF').to include_elixir_syntax('elixirFunctionCall', 'func')
+      Mod.func
+    EOF
+  end
 end

--- a/spec/syntax/function_spec.rb
+++ b/spec/syntax/function_spec.rb
@@ -101,4 +101,18 @@ describe 'function syntax' do
       Module .           func
     EOF
   end
+
+  it 'detects piped functions with parenthesis' do
+    expect(<<~'EOF').to include_elixir_syntax('elixirFunctionCall', 'func')
+      one_func()
+      |> func()
+    EOF
+  end
+
+  it 'detects piped functions without parenthesis' do
+    expect(<<~'EOF').to include_elixir_syntax('elixirFunctionCall', 'func')
+      one_func()
+      |> func
+    EOF
+  end
 end

--- a/spec/syntax/function_spec.rb
+++ b/spec/syntax/function_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 
 describe 'function syntax' do
   it 'doesnt treat underscored functions like unsued variables' do
-    expect(<<~EOF).to include_elixir_syntax('elixirId', '__ensure_defimpl__')
+    expect(<<~EOF).to include_elixir_syntax('elixirFunctionCall', '__ensure_defimpl__')
       defp derive(protocol, for, struct, opts, env) do
         # ... code ...
         __ensure_defimpl__(protocol, for, env)
@@ -97,7 +97,7 @@ describe 'function syntax' do
   end
 
   it 'ignores spacing between module and function names' do
-    expect(<<~'EOF').not_to include_elixir_syntax('elixirFunctionCall', 'func')
+    expect(<<~'EOF').to include_elixir_syntax('elixirFunctionCall', 'func')
       Module .           func
     EOF
   end

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -52,6 +52,7 @@ syn match elixirVariable '&\d\+'
 
 syn match elixirFunctionCall '\<[a-z_]\w*[!?]\?\(\s*\.\?\s*(\|\s\+[a-zA-Z0-9@:\'\"\[]\)\@='
 syn match elixirFunctionCall '\(:\w\+\s*\.\s*\|[A-Z]\w*\s*\.\s*\)\@<=[a-z_]\w*[!?]\?'
+syn match elixirFunctionCall '\(>\s+\)\<[a-z_]\w*[!?]\?'
 
 syn keyword elixirPseudoVariable __FILE__ __DIR__ __MODULE__ __ENV__ __CALLER__
 

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -50,6 +50,9 @@ syn keyword elixirBoolean true false nil
 syn match elixirVariable '@[a-z]\w*'
 syn match elixirVariable '&\d\+'
 
+syn match elixirFunctionCall '\<[a-z_]\w*[!?]\?\(\s*\.\?\s*(\)\@='
+syn match elixirFunctionCall '\([A-Z]\w*\s*\.\s*\)\@<=[a-z_]\w*[!?]\?'
+
 syn keyword elixirPseudoVariable __FILE__ __DIR__ __MODULE__ __ENV__ __CALLER__
 
 syn match elixirNumber '\<-\?\d\(_\?\d\)*\(\.[^[:space:][:digit:]]\@!\(_\?\d\)*\)\?\([eE][-+]\?\d\(_\?\d\)*\)\?\>'
@@ -197,6 +200,7 @@ hi def link elixirStructDefine               Define
 hi def link elixirExUnitMacro                Define
 hi def link elixirModuleDeclaration          Type
 hi def link elixirPrivateFunctionDeclaration elixirFunctionDeclaration
+hi def link elixirFunctionCall               Function
 hi def link elixirFunctionDeclaration        Function
 hi def link elixirPrivateMacroDeclaration    elixirMacroDeclaration
 hi def link elixirMacroDeclaration           Macro

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -51,7 +51,7 @@ syn match elixirVariable '@[a-z]\w*'
 syn match elixirVariable '&\d\+'
 
 syn match elixirFunctionCall '\<[a-z_]\w*[!?]\?\(\s*\.\?\s*(\)\@='
-syn match elixirFunctionCall '\([A-Z]\w*\s*\.\s*\)\@<=[a-z_]\w*[!?]\?'
+syn match elixirFunctionCall '\(:\w\+\s*\.\s*\|[A-Z]\w*\s*\.\s*\)\@<=[a-z_]\w*[!?]\?'
 
 syn keyword elixirPseudoVariable __FILE__ __DIR__ __MODULE__ __ENV__ __CALLER__
 

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -50,7 +50,7 @@ syn keyword elixirBoolean true false nil
 syn match elixirVariable '@[a-z]\w*'
 syn match elixirVariable '&\d\+'
 
-syn match elixirFunctionCall '\<[a-z_]\w*[!?]\?\(\s*\.\?\s*(\)\@='
+syn match elixirFunctionCall '\<[a-z_]\w*[!?]\?\(\s*\.\?\s*(\|\s\+[a-zA-Z0-9@:\'\"\[]\)\@='
 syn match elixirFunctionCall '\(:\w\+\s*\.\s*\|[A-Z]\w*\s*\.\s*\)\@<=[a-z_]\w*[!?]\?'
 
 syn keyword elixirPseudoVariable __FILE__ __DIR__ __MODULE__ __ENV__ __CALLER__


### PR DESCRIPTION
# Description
Function call highlight was [added to elixir syntax highlight on Sublime Text](https://github.com/elixir-editors/elixir-tmbundle/pull/179) and I thought that was a neat addition as it makes it easier to scan what are function vs variables in the code. I propose we can also add this to our Vim syntax highlight.

# Result
![image](https://user-images.githubusercontent.com/1727723/63980491-308b9200-ca92-11e9-9d56-5dfc6e351eea.png)
