### PR TITLE
Fix highlight for atoms containing @ character

### DIFF
--- a/spec/syntax/atom_spec.rb
+++ b/spec/syntax/atom_spec.rb
@@ -88,4 +88,19 @@ describe 'Atom syntax' do
     end
     EOF
   end
+
+  it 'detects atoms containing @ in it' do
+    expect(<<~EOF).to include_elixir_syntax('elixirAtom', '@somewhere')
+      :atom@somewhere
+    EOF
+    expect(<<~EOF).to include_elixir_syntax('elixirAtom', '@somewhere')
+      [atom@somewhere: nil]
+    EOF
+  end
+
+  it 'detects atoms containing Unicode letters in it' do
+    expect(<<~EOF).to include_elixir_syntax('elixirAtom', 'ó')
+      :atóm
+    EOF
+  end
 end

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -41,9 +41,9 @@ syn match   elixirOperator '\\\\\|::\|\*\|/\|\~\~\~\|@'
 
 syn match   elixirAlias '\([a-z]\)\@<![A-Z]\w*\%(\.[A-Z]\w*\)*'
 
-syn match   elixirAtom '\(:\)\@<!:\%([a-zA-Z_]\w*\%([?!]\|=[>=]\@!\)\?\|<>\|===\?\|>=\?\|<=\?\)'
+syn match   elixirAtom '\(:\)\@<!:\%([a-zA-Z_]\%(\w\|@\|\P\)*\%([?!]\|=[>=]\@!\)\?\|<>\|===\?\|>=\?\|<=\?\)'
 syn match   elixirAtom '\(:\)\@<!:\%(<=>\|&&\?\|%\(()\|\[\]\|{}\)\|++\?\|--\?\|||\?\|!\|//\|[%&`/|]\)'
-syn match   elixirAtom "\%([a-zA-Z_]\w*[?!]\?\):\(:\)\@!"
+syn match   elixirAtom "\%([a-zA-Z_]\%(\w\|@\|\P\)*[?!]\?\):\(:\)\@!"
 
 syn keyword elixirBoolean true false nil
 


### PR DESCRIPTION
Fixes #500

I fixed it by just expanding the pool of characters possible in an atom from `\w` to also accepts Unicode characters with `\P` and `@`. This way I think it is more in line with [syntax specification](https://hexdocs.pm/elixir/master/syntax-reference.html#atoms).