### PR TITLE
Fix highlight for atoms containing @ character

### DIFF
--- a/spec/syntax/atom_spec.rb
+++ b/spec/syntax/atom_spec.rb
@@ -88,4 +88,31 @@ describe 'Atom syntax' do
     end
     EOF
   end
+
+  it 'detects atoms containing @ in it' do
+    expect(<<~EOF).to include_elixir_syntax('elixirAtom', '@somewhere')
+      :atom@somewhere
+    EOF
+    expect(<<~EOF).to include_elixir_syntax('elixirAtom', '@somewhere')
+      [atom@somewhere: nil]
+    EOF
+  end
+
+  it 'detects atoms containing Unicode letters in it' do
+    expect(<<~EOF).to include_elixir_syntax('elixirAtom', 'ó')
+      :atóm
+    EOF
+  end
+
+  it 'does not incorrectly detects spaces as part of the atom' do
+    input = <<~EOF
+      {:power_assert, "~> 0.2.0", only: :test}
+    EOF
+    expect(input).to include_elixir_syntax('elixirAtom', 'power_assert')
+    expect(input).to include_elixir_syntax('elixirAtom', 'only')
+    expect(input).to include_elixir_syntax('elixirAtom', 'test')
+    expect(input).not_to include_elixir_syntax('elixirAtom', '0.2.0')
+    expect(input).not_to include_elixir_syntax('elixirAtom', '{')
+    expect(input).not_to include_elixir_syntax('elixirAtom', '}')
+  end
 end

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -41,9 +41,9 @@ syn match   elixirOperator '\\\\\|::\|\*\|/\|\~\~\~\|@'
 
 syn match   elixirAlias '\([a-z]\)\@<![A-Z]\w*\%(\.[A-Z]\w*\)*'
 
-syn match   elixirAtom '\(:\)\@<!:\%([a-zA-Z_]\w*\%([?!]\|=[>=]\@!\)\?\|<>\|===\?\|>=\?\|<=\?\)'
+syn match   elixirAtom '\(:\)\@<!:\%(\%(\w\|@\|[^\d0-\d127]\)\+\%(=[>=]\@!\)\?\|<>\|===\?\|>=\?\|<=\?\)'
 syn match   elixirAtom '\(:\)\@<!:\%(<=>\|&&\?\|%\(()\|\[\]\|{}\)\|++\?\|--\?\|||\?\|!\|//\|[%&`/|]\)'
-syn match   elixirAtom "\%([a-zA-Z_]\w*[?!]\?\):\(:\)\@!"
+syn match   elixirAtom "\%(\w\|@\|[^\d0-\d127]\)\+:\(:\)\@!"
 
 syn keyword elixirBoolean true false nil
 


### PR DESCRIPTION
Fixes #510 

In eb06df6 I used a regexp that was matching too many things. I completely forgot that spaces are also printable characters 🤦‍♂ 

This PR comes with a new version using `[^\d0-\d127]` to match those special characters. This will:

- **Not** match spaces, so atoms will be matched correctly;
- Match accented characters like `á ó é`;
- Match least common characters like `ಠ` which **are** valid in an atom like `:ಠ‿ಠ`;
- Match **some** invalid characters;

Elixir actually accepts any UTF-8 letter as atoms and Vim does not support Unicode modifiers AFAIK, so using something like `\p{L}` is not possible 😞 
I went with the route of adding any non-ASCII on top of words and @s as it gave us more positive results and the false-positives will raise errors when compiled, so they are easily fixable. I still can't decide by myself if we should add those false-positives or not.
WDYT?

The other option would be to remove support for accents and other UTF-8 characters and only highlight those atoms with `\w` and `@` matched chars.