### PR TITLE
Use /usr/bin/env to find bash

### DIFF
--- a/manual_install.sh
+++ b/manual_install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 mkdir -p ~/.vim/
 


### PR DESCRIPTION
On some systems, bash does not lie under /bin/. For instance, NixOS.