### PR TITLE
Add ctags to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 profile.log
 test_indent.result
+doc/tags


### PR DESCRIPTION
I submodule this repo to use it with pathogen and it keeps breaking when I update because of untracked content in the submodule. This should fix the issue