### PR TITLE
Add Surface support and EEX sigil support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Features:
 
 * Syntax highlighting for Elixir and EEx files
-* Filetype detection for `.ex`, `.exs`, `.eex` and `.leex` files
+* Filetype detection for `.ex`, `.exs`, `.eex`, `.leex`, and `.sface` files
 * Automatic indentation
 * Integration between Ecto projects and [vim-dadbod][] for running SQL queries
   on defined Ecto repositories

--- a/doc/elixir.txt
+++ b/doc/elixir.txt
@@ -19,7 +19,7 @@ INTRODUCTION					*elixir-introduction*
 *elixir* provides Vim configuration files for Elixir http://elixir-lang.org/
 
 * Syntax highlighting for Elixir and EEx files
-* Filetype detection for `.ex`, `.exs`, `.eex` and `.leex` files
+* Filetype detection for `.ex`, `.exs`, `.eex`, `.leex`, and `.sface` files
 * Automatic indentation
 * Integration between Ecto projects and |vim-dadbod| for running SQL queries
   on defined Ecto repositories

--- a/ftdetect/elixir.vim
+++ b/ftdetect/elixir.vim
@@ -1,5 +1,5 @@
 au BufRead,BufNewFile *.ex,*.exs set filetype=elixir
-au BufRead,BufNewFile *.eex,*.leex set filetype=eelixir
+au BufRead,BufNewFile *.eex,*.leex,*.sface set filetype=eelixir
 au BufRead,BufNewFile mix.lock set filetype=elixir
 au BufRead,BufNewFile * call s:DetectElixir()
 

--- a/ftplugin/eelixir.vim
+++ b/ftplugin/eelixir.vim
@@ -23,7 +23,10 @@ if !exists("b:eelixir_subtype")
     let b:eelixir_subtype = matchstr(&filetype,'^leex\.\zs\w\+')
   endif
   if b:eelixir_subtype == ''
-    let b:eelixir_subtype = matchstr(substitute(expand("%:t"),'\c\%(\.eex\|\.leex\|\.eelixir\)\+$','',''),'\.\zs\w\+$')
+    let b:eelixir_subtype = matchstr(&filetype,'^sface\.\zs\w\+')
+  endif
+  if b:eelixir_subtype == ''
+    let b:eelixir_subtype = matchstr(substitute(expand("%:t"),'\c\%(\.eex\|\.sface\|\.leex\|\.eelixir\)\+$','',''),'\.\zs\w\+$')
   endif
   if b:eelixir_subtype == 'ex'
     let b:eelixir_subtype = 'elixir'
@@ -92,6 +95,10 @@ endif
 if !exists('b:surround_35')
   " When using surround `#` (ASCII 35) would provide `<%# selection %>`
   let b:surround_35 = "<%# \r %>"
+endif
+if !exists('b:surround_123')
+  " When using surround `{` (ASCII 123) would provide `{{ selection }}`
+  let b:surround_123 = "{{ \r }}"
 endif
 if !exists('b:surround_5')
   " When using surround `<C-e>` (ASCII 5 `ENQ`) would provide `<% selection %>\n<% end %>`

--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -28,7 +28,7 @@ let &l:path =
       \   &g:path
       \ ], ',')
 setlocal includeexpr=elixir#util#get_filename(v:fname)
-setlocal suffixesadd=.ex,.exs,.eex,.leex,.erl,.xrl,.yrl,.hrl
+setlocal suffixesadd=.ex,.exs,.eex,.leex,.sface,.erl,.xrl,.yrl,.hrl
 
 let &l:define = 'def\(macro\|guard\|delegate\)\=p\='
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -123,9 +123,15 @@ module EexBuffer
   end
 end
 
-module EexBuffer
+module LeexBuffer
   def self.new
     Buffer.new(VIM, :leex)
+  end
+end
+
+module SurfaceBuffer
+  def self.new
+    Buffer.new(VIM, :sface)
   end
 end
 
@@ -154,7 +160,8 @@ end
 {
   be_elixir_indentation:  :ex,
   be_eelixir_indentation: :eex,
-  be_leelixir_indentation: :leex
+  be_leelixir_indentation: :leex,
+  be_surface_indentation: :sface
 }.each do |matcher, type|
   RSpec::Matchers.define matcher do
     buffer = Buffer.new(VIM, type)
@@ -182,7 +189,8 @@ end
 {
   include_elixir_syntax:  :ex,
   include_eelixir_syntax: :eex,
-  include_leelixir_syntax: :leex
+  include_leelixir_syntax: :leex,
+  include_surface_syntax: :sface
 }.each do |matcher, type|
   RSpec::Matchers.define matcher do |syntax, pattern|
     buffer = Buffer.new(VIM, type)

--- a/spec/syntax/embedded_elixir_spec.rb
+++ b/spec/syntax/embedded_elixir_spec.rb
@@ -26,3 +26,36 @@ describe 'Embedded Elixir syntax' do
     expect('<% end %>').to include_eelixir_syntax('eelixirDelimiter', '%>')
   end
 end
+
+describe 'Embedded Live Elixir syntax' do
+  it 'elixir' do
+    expect('<%= if true do %>').to include_leelixir_syntax('elixirKeyword', 'if')
+    expect('<%= if true do %>').to include_leelixir_syntax('elixirBoolean', 'true')
+  end
+
+  it 'expression' do
+    expect('<%= if true do %>').to include_leelixir_syntax('eelixirExpression', 'if')
+    expect('<% end %>').to include_leelixir_syntax('eelixirExpression', 'end')
+  end
+
+  it 'quote' do
+    expect('<%% def f %>').to include_leelixir_syntax('eelixirQuote', 'def')
+  end
+
+  it 'comment' do
+    expect('<%# foo bar baz %>').to include_leelixir_syntax('eelixirComment', 'foo')
+  end
+
+  it 'delimiters' do
+    expect('<% end %>').to include_leelixir_syntax('eelixirDelimiter', '<%')
+    expect('<% end %>').to include_leelixir_syntax('eelixirDelimiter', '%>')
+  end
+end
+
+describe 'Embedded Surface syntax' do
+  it 'elixir' do
+    expect('{{ @foo }}').to include_surface_syntax('elixirVariable', 'foo')
+    expect('{{ @foo }}').to include_surface_syntax('surfaceDelimiter', '{{')
+    expect('{{ @foo }}').to include_surface_syntax('surfaceDelimiter', '}}')
+  end
+end

--- a/spec/syntax/sigil_spec.rb
+++ b/spec/syntax/sigil_spec.rb
@@ -91,6 +91,15 @@ describe 'Sigil syntax' do
     it 'Live EEx' do
       expect('~L"""liveview template"""').to include_elixir_syntax('elixirSigilDelimiter', '"""')
     end
+
+    it 'Surface EEx' do
+      expect('~H"""surface template"""').to include_elixir_syntax('elixirSigilDelimiter', '"""')
+    end
+
+    it 'EEx' do
+      expect('~E"""Phoenix.HTML template"""').to include_elixir_syntax('elixirSigilDelimiter', '"""')
+      expect('~e"""Phoenix.HTML template"""').to include_elixir_syntax('elixirSigilDelimiter', '"""')
+    end
   end
 
   describe 'lower case' do

--- a/syntax/eelixir.vim
+++ b/syntax/eelixir.vim
@@ -23,7 +23,10 @@ if !exists("b:eelixir_subtype")
     let b:eelixir_subtype = matchstr(&filetype,'^leex\.\zs\w\+')
   endif
   if b:eelixir_subtype == ''
-    let b:eelixir_subtype = matchstr(substitute(expand("%:t"),'\c\%(\.eex\|\.leex\|\.eelixir\)\+$','',''),'\.\zs\w\+$')
+    let b:eelixir_subtype = matchstr(&filetype,'^sface\.\zs\w\+')
+  endif
+  if b:eelixir_subtype == ''
+    let b:eelixir_subtype = matchstr(substitute(expand("%:t"),'\c\%(\.eex\|\.sface\|\.leex\|\.eelixir\)\+$','',''),'\.\zs\w\+$')
   endif
   if b:eelixir_subtype == 'ex'
     let b:eelixir_subtype = 'elixir'
@@ -48,16 +51,18 @@ endif
 
 syn include @elixirTop syntax/elixir.vim
 
-syn cluster eelixirRegions contains=eelixirBlock,eelixirExpression,eelixirComment
+syn cluster eelixirRegions contains=eelixirBlock,surfaceExpression,eelixirExpression,eelixirComment
 
 exe 'syn region  eelixirExpression matchgroup=eelixirDelimiter start="<%"  end="%\@<!%>" contains=@elixirTop  containedin=ALLBUT,@eelixirRegions keepend'
 exe 'syn region  eelixirExpression matchgroup=eelixirDelimiter start="<%=" end="%\@<!%>" contains=@elixirTop  containedin=ALLBUT,@eelixirRegions keepend'
+exe 'syn region  surfaceExpression matchgroup=surfaceDelimiter start="{{" end="}}" contains=@elixirTop  containedin=ALLBUT,@eelixirRegions keepend'
 exe 'syn region  eelixirQuote      matchgroup=eelixirDelimiter start="<%%" end="%\@<!%>" contains=@elixirTop  containedin=ALLBUT,@eelixirRegions keepend'
 exe 'syn region  eelixirComment    matchgroup=eelixirDelimiter start="<%#" end="%\@<!%>" contains=elixirTodo,@Spell containedin=ALLBUT,@eelixirRegions keepend'
 
 " Define the default highlighting.
 
 hi def link eelixirDelimiter PreProc
+hi def link surfaceDelimiter PreProc
 hi def link eelixirComment   Comment
 
 let b:current_syntax = 'eelixir'

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -111,7 +111,9 @@ syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z('''\)+ end=
 syntax include @HTML syntax/html.vim
 unlet b:current_syntax
 syntax region elixirLiveViewSigil matchgroup=elixirSigilDelimiter keepend start=+\~L\z("""\)+ end=+^\s*\z1+ skip=+\\"+ contains=@HTML fold
-
+syntax region elixirSurfaceSigil matchgroup=elixirSigilDelimiter keepend start=+\~H\z("""\)+ end=+^\s*\z1+ skip=+\\"+ contains=@HTML fold
+syntax region elixirPhoenixESigil matchgroup=elixirSigilDelimiter keepend start=+\~E\z("""\)+ end=+^\s*\z1+ skip=+\\"+ contains=@HTML fold
+syntax region elixirPhoenixeSigil matchgroup=elixirSigilDelimiter keepend start=+\~e\z("""\)+ end=+^\s*\z1+ skip=+\\"+ contains=@HTML fold
 
 " Documentation
 if exists('g:elixir_use_markdown_for_docs') && g:elixir_use_markdown_for_docs


### PR DESCRIPTION
This adds support for *.sface files, introduced by [Surface](https://hex.pm/packages/surface) ([demo](http://surface-demo.msaraiva.io/getting_started)). This is much like the existing embedded elixir types, but instead of `<% ... %>` for interpolation, it uses `{{ ... }}`, and uses the `~H` sigil when in Elixir files..

When adding the `~H` support, I noticed that `~E` and `~e` were not included, and found this reported in #534. I decided to include that here as well, so this PR also resolves #534 

Before:
![image](https://user-images.githubusercontent.com/643967/100321482-c1e8fd00-2f90-11eb-9301-21e526666c5e.png)

After:
![image](https://user-images.githubusercontent.com/643967/100319942-79c8db00-2f8e-11eb-9f27-8cceae8f27f8.png)
