### PR TITLE
Auto-indent embedded views

### DIFF
--- a/autoload/elixir/indent.vim
+++ b/autoload/elixir/indent.vim
@@ -20,6 +20,7 @@ function! elixir#indent#indent(lnum)
   call cursor(lnum, 0)
 
   let handlers = [
+        \'inside_embedded_view',
         \'top_of_file',
         \'starts_with_string_continuation',
         \'following_trailing_binary_operator',
@@ -63,6 +64,17 @@ endfunction
 
 function! s:prev_starts_with(context, expr)
   return s:_starts_with(a:context.prev_nb_text, a:expr, a:context.prev_nb_lnum)
+endfunction
+
+function! s:in_embedded_view()
+  let groups = map(synstack(line('.'), col('.')), "synIDattr(v:val, 'name')")
+  for group in ['elixirPhoenixESigil', 'elixirLiveViewSigil', 'elixirSurfaceSigil']
+    if index(groups, group) >= 0
+      return 1
+    endif
+  endfor
+
+  return 0
 endfunction
 
 " Returns 0 or 1 based on whether or not the text starts with the given
@@ -152,6 +164,104 @@ function! s:find_last_pos(lnum, text, match)
     end
     let c -= 1
   endwhile
+
+  return -1
+endfunction
+
+function! elixir#indent#handle_inside_embedded_view(context)
+  if !s:in_embedded_view()
+    return -1
+  endif
+
+  " Multi-line Surface data delimiters
+  let pair_lnum = searchpair('{{', '', '}}', 'bW', "line('.') == ".a:context.lnum." || s:is_string_or_comment(line('.'), col('.'))", max([0, a:context.lnum - g:elixir_indent_max_lookbehind]))
+  if pair_lnum
+    if a:context.text =~ '}}$'
+      return indent(pair_lnum)
+    elseif a:context.text =~ '}}*>$'
+      return -1
+    elseif s:prev_ends_with(a:context, '[\|%{')
+      return indent(a:context.prev_nb_lnum) + s:sw()
+    elseif a:context.prev_nb_text =~ ',$'
+      return indent(a:context.prev_nb_lnum)
+    else
+      return indent(pair_lnum) + s:sw()
+    endif
+  endif
+
+  " Multi-line opening tag -- >, />, or %> are on a different line that their opening <
+  let pair_lnum = searchpair('^\s\+<.*[^>]$', '', '^[^<]*[/%}]\?>$', 'bW', "line('.') == ".a:context.lnum." || s:is_string_or_comment(line('.'), col('.'))", max([0, a:context.lnum - g:elixir_indent_max_lookbehind]))
+  if pair_lnum
+    if a:context.text =~ '^\s\+\%\(>\|\/>\|%>\|}}>\)$'
+      call s:debug("current line is a lone >, />, or %>")
+      return indent(pair_lnum)
+    elseif a:context.text =~ '\%\(>\|\/>\|%>\|}}>\)$'
+      call s:debug("current line ends in >, />, or %>")
+      if s:prev_ends_with(a:context, ',')
+        return indent(a:context.prev_nb_lnum)
+      else
+        return -1
+      endif
+    else
+      call s:debug("in the body of a multi-line opening tag")
+      return indent(pair_lnum) + s:sw()
+    endif
+  endif
+
+  " Special cases
+  if s:prev_ends_with(a:context, '^[^<]*do\s%>')
+    call s:debug("prev line closes a multi-line do block")
+    return indent(a:context.prev_nb_lnum)
+  elseif a:context.prev_nb_text =~ 'do\s*%>$'
+    call s:debug("prev line opens a do block")
+    return indent(a:context.prev_nb_lnum) + s:sw()
+  elseif a:context.text =~ '^\s\+<\/[a-zA-Z0-9\.\-_]\+>\|<% end %>'
+    call s:debug("a single closing tag")
+    if a:context.prev_nb_text =~ '^\s\+<[^%\/]*[^/]>.*<\/[a-zA-Z0-9\.\-_]\+>$'
+      call s:debug("opening and closing tags are on the same line")
+      return indent(a:context.prev_nb_lnum) - s:sw()
+    elseif a:context.prev_nb_text =~ '^\s\+<[^%\/]*[^/]>\|\s\+>' 
+      call s:debug("prev line is opening html tag or single >")
+      return indent(a:context.prev_nb_lnum)
+    elseif s:prev_ends_with(a:context, '^[^<]*\%\(do\s\)\@<!%>')
+      call s:debug("prev line closes a multi-line eex tag")
+      return indent(a:context.prev_nb_lnum) - 2 * s:sw()
+    else
+      return indent(a:context.prev_nb_lnum) - s:sw()
+    endif
+  elseif a:context.text =~ '^\s*<%\s*\%(end\|else\|catch\|rescue\)\>.*%>'
+    call s:debug("eex middle or closing eex tag")
+    return indent(a:context.prev_nb_lnum) - s:sw()
+  elseif a:context.prev_nb_text =~ '\s*<\/\|<% end %>$'
+    call s:debug("prev is closing tag")
+    return indent(a:context.prev_nb_lnum)
+  elseif a:context.prev_nb_text =~ '^\s\+<[^%\/]*[^/]>.*<\/[a-zA-Z0-9\.\-_]\+>$'
+    call s:debug("opening and closing tags are on the same line")
+    return indent(a:context.prev_nb_lnum)
+  elseif s:prev_ends_with(a:context, '\s\+\/>')
+    call s:debug("prev ends with a single \>")
+    return indent(a:context.prev_nb_lnum)
+  elseif s:prev_ends_with(a:context, '^[^<]*\/>')
+    call s:debug("prev line is closing a multi-line self-closing tag")
+    return indent(a:context.prev_nb_lnum) - s:sw()
+  elseif s:prev_ends_with(a:context, '^\s\+<.*\/>')
+    call s:debug("prev line is closing self-closing tag")
+    return indent(a:context.prev_nb_lnum)
+  elseif a:context.prev_nb_text =~ '^\s\+%\?>$'
+    call s:debug("prev line is a single > or %>")
+    return indent(a:context.prev_nb_lnum) + s:sw()
+  endif
+
+  " Simple HTML (ie, opening tag is not split across lines)
+  let pair_lnum = searchpair('^\s\+<[^%\/].*[^\/>]>$', '', '^\s\+<\/\w\+>$', 'bW', "line('.') == ".a:context.lnum." || s:is_string_or_comment(line('.'), col('.'))", max([0, a:context.lnum - g:elixir_indent_max_lookbehind]))
+  if pair_lnum
+    call s:debug("simple HTML")
+    if a:context.text =~ '^\s\+<\/\w\+>$'
+      return indent(pair_lnum)
+    else
+      return indent(pair_lnum) + s:sw()
+    endif
+  endif
 
   return -1
 endfunction

--- a/indent/elixir.vim
+++ b/indent/elixir.vim
@@ -6,7 +6,7 @@ let b:did_indent = 1
 setlocal indentexpr=elixir#indent(v:lnum)
 
 setlocal indentkeys+==after,=catch,=do,=else,=end,=rescue,
-setlocal indentkeys+=*<Return>,=->,=\|>,=<>,0},0],0)
+setlocal indentkeys+=*<Return>,=->,=\|>,=<>,0},0],0),>
 
 " TODO: @jbodah 2017-02-27: all operators should cause reindent when typed
 

--- a/spec/indent/embedded_views_spec.rb
+++ b/spec/indent/embedded_views_spec.rb
@@ -1,0 +1,263 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Indenting embedded views' do
+  i <<~EOF
+    def render(assigns) do
+      ~L"""
+      <div>
+        Some content
+      </div>
+      """
+    end
+  EOF
+
+  i <<~EOF
+    def render(assigns) do
+      ~H"""
+      <div class="theres a-/ in the class names from tailwind">
+        <div class="some more classes">
+          This is immediately nested
+          <div>
+            <input type="number" value="2" />
+            There's a self-closing tag
+          </div>
+        </div>
+      </div>
+      """
+    end
+  EOF
+
+  i <<~EOF
+    def render(assigns) do
+      ~L"""
+      <div id="123456">
+        Some content
+      </div>
+      """
+    end
+  EOF
+
+  i <<~EOF
+    def render(assigns) do
+      ~L"""
+      <div
+        id="123456"
+      >
+        Some content
+      </div>
+      """
+    end
+  EOF
+
+  i <<~EOF
+    def render(assigns) do
+      ~L"""
+      <div />
+      <p>Some paragraph</p>
+      """
+    end
+  EOF
+
+  i <<~EOF
+    def render(assigns) do
+      ~L"""
+      <div>
+        it
+        <div>
+          keeps
+          <div>
+            nesting
+          </div>
+        </div>
+      </div>
+      """
+    end
+  EOF
+
+  i <<~EOF
+    def render(assgins) do
+      ~L"""
+      <div>
+        <%= for i <- iter do %>
+          <div><%= i %></div>
+        <% end %>
+      </div>
+      """
+    end
+  EOF
+
+  i <<~EOF
+    def render(assigns) do
+      ~L"""
+      <%= live_component @socket,
+        Component,
+        id: "<%= @id %>",
+        user: @user do
+      %>
+
+        <main>
+          <header>
+            <h1>Some Header</h1>
+          </header>
+          <section>
+            <h1>Some Section</h1>
+            <p>
+              I'm some text
+            </p>
+          </section>
+        </main>
+
+      <% end %>
+      """
+    end
+  EOF
+
+  i <<~EOF
+    def render(assigns) do
+      ~L"""
+      <%= render_component,
+        @socket,
+        Component do %>
+
+        <p>Multi-line opening eex tag that takes a block</p>
+      <% end %>
+      """
+    end
+  EOF
+
+  i <<~EOF
+    def render(assigns) do
+      ~L"""
+      <div>
+        <%= render_component,
+          @socket,
+          Component %>
+      </div>
+
+      <%= render_component,
+        @socket,
+        Component %>
+      <p>Multi-line single eex tag</p>
+      """
+    end
+  EOF
+
+  i <<~EOF
+    def render(assigns) do
+      ~H"""
+      <Component
+        foo={{
+          foo: [
+            'one',
+            'two',
+            'three'
+          ],
+          bar: %{
+            "foo" => "bar"
+          }
+        }}
+      />
+      """
+    end
+  EOF
+
+  i <<~EOF
+    def render(assigns) do
+      ~L"""
+      <%= live_component @socket,
+        Component,
+        id: "<%= @id %>",
+        team: @team do
+      %>
+
+        <div>
+          <div>
+            <div>
+              A deeply nested tree
+              <div>
+                with trailing whitespace
+
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div id="id-ends-with-greater-than->"
+          propWithEexTag="<%= @id %>"
+          anotherProp="foo"
+        />
+
+        <%= for i <- iter do %>
+          <div><%= i %></div>
+        <% end %>
+
+        <div
+          opts={{
+            opt1: "optA",
+            opt2: "optB"
+          }}
+          id="hi"
+          bye="hi" />
+
+        <ul>
+          <li :for={{ item <- @items }}>
+            {{ item }}
+          </li>
+        </ul>
+
+        <div id="hi">
+          Hi <p>hi</p>
+          I'm ok, ok?
+          <div>
+            hi there!
+          </div>
+          <div>
+            <div>
+              <p>hi</p>
+              <hr />
+            </div>
+          </div>
+        </div>
+
+        <Some.Surface.Component />
+
+        <Another
+          prop="prop"
+          prop2="prop2"
+        >
+          <div>content</div>
+        </Another>
+
+        <div foo />
+
+        <div>hi</div>
+
+        <div>
+          <div>
+            content
+          </div>
+          <div />
+          <div>
+            content in new div after a self-closing div
+          </div>
+        </div>
+
+        <p
+          id="<%= @id %>"
+          class="multi-line opening single letter p tag"
+        >
+          <%= @solo.eex_tag %>
+          <Nested
+            prop="nested"
+          >
+            content
+          </Nested>
+        </p>
+
+      <% end %>
+      """
+    end
+  EOF
+end


### PR DESCRIPTION
I'm submitting this PR as a request for feedback.  It aims to solve the indentation issues with embedded views (stuff between `~L`, `~H`, `~e`, and `~E`) as per #536.  I couldn't figure out how to embed indent syntax—and assumed this is probably not possible—so this is what I've come up with.  The aim is to provide an improved experience over the current behaviour, not to write a full re-implementation HTML indentation.

First and foremost, while I've added some test cases, I cannot for the life of me figure out how to run them.  `$ bundle exec parallel_rspec spec` has every test failing with `Vimrunner::NoSuitableVimError`.  `bin/vim` boots up a vim instance but I'm not sure how to target it.

Otherwise, there are a couple of outstanding issues I'm aware of:
- There is some funky behaviour when using [vim-surround](tpope/vim-surround) on a multi-line opening tag, though this seems to be current behaviour of the plugin.
- [close-tag](/alvan/vim-closetag)'s `>` insert mapping leaves the cursor at the same indentation level as the opening tag.
- `/>` on a line by itself is caught by the `top_of_file` handler.  Moving my proposed handler to the opening position fixes this, but I'm currently worried about doing so since I can't run the tests.

Thank you!