### PR TITLE
Recursively search directories for files

### DIFF
--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -21,10 +21,10 @@ setlocal commentstring=#\ %s
 
 let &l:path =
       \ join([
-      \   'lib',
-      \   'src',
-      \   'deps/**/lib',
-      \   'deps/**/src',
+      \   'lib/**',
+      \   'src/**',
+      \   'deps/**/lib/**',
+      \   'deps/**/src/**',
       \   &g:path
       \ ], ',')
 setlocal includeexpr=elixir#util#get_filename(v:fname)

--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -23,6 +23,7 @@ let &l:path =
       \ join([
       \   'lib/**',
       \   'src/**',
+      \   'test/**',
       \   'deps/**/lib/**',
       \   'deps/**/src/**',
       \   &g:path


### PR DESCRIPTION
Thanks a lot for this plugin. I noticed that when using the `:find` command that sub-directories are not searched for elixir source files. If this was intentional, please disregard this PR. Otherwise, these changes will add support for finding files in a tree of sub-directories.