### PR TITLE
Added char lists syntax highlighting

### DIFF
--- a/autoload/elixir/indent.vim
+++ b/autoload/elixir/indent.vim
@@ -104,7 +104,7 @@ endfunction
 " Returns 0 or 1 based on whether or not the given line number and column
 " number pair is a string or comment
 function! s:is_string_or_comment(line, col)
-  return s:syntax_name(a:line, a:col) =~ '\%(String\|Comment\)'
+  return s:syntax_name(a:line, a:col) =~ '\%(String\|Comment\|CharList\)'
 endfunction
 
 function! s:syntax_name(line, col)

--- a/spec/indent/basic_spec.rb
+++ b/spec/indent/basic_spec.rb
@@ -558,4 +558,12 @@ describe 'Basic indenting' do
     :send
   end
   EOF
+
+  i <<~EOF
+  defmodule Hi do
+    def hello_world do
+      "end"
+      'end'
+    end
+  EOF
 end

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -76,7 +76,7 @@ syn region elixirStruct matchgroup=elixirStructDelimiter start="%\(\w\+{\)\@=" e
 
 syn region elixirMap matchgroup=elixirMapDelimiter start="%{" end="}" contains=ALLBUT,@elixirNotTop fold
 
-syn region elixirString  matchgroup=elixirStringDelimiter start=+\z('\)+   end=+\z1+ skip=+\\\\\|\\\z1+  contains=@Spell,@elixirStringContained
+syn region elixirCharList  matchgroup=elixirCharListDelimiter start=+\z('\)+   end=+\z1+ skip=+\\\\\|\\\z1+  contains=@Spell
 syn region elixirString  matchgroup=elixirStringDelimiter start=+\z("\)+   end=+\z1+ skip=+\\\\\|\\\z1+  contains=@Spell,@elixirStringContained
 syn region elixirString  matchgroup=elixirStringDelimiter start=+\z('''\)+ end=+^\s*\z1+ contains=@Spell,@elixirStringContained
 syn region elixirString  matchgroup=elixirStringDelimiter start=+\z("""\)+ end=+^\s*\z1+ contains=@Spell,@elixirStringContained
@@ -88,7 +88,7 @@ syn match elixirString             "\(\w\)\@<!?\%(\\\(x\d{1,2}\|\h{1,2}\h\@!\>\|
 syn region elixirBlock              matchgroup=elixirBlockDefinition start="\<do\>:\@!" end="\<end\>" contains=ALLBUT,@elixirNotTop fold
 syn region elixirAnonymousFunction  matchgroup=elixirBlockDefinition start="\<fn\>"     end="\<end\>" contains=ALLBUT,@elixirNotTop fold
 
-syn region elixirArguments start="(" end=")" contained contains=elixirOperator,elixirAtom,elixirPseudoVariable,elixirAlias,elixirBoolean,elixirVariable,elixirUnusedVariable,elixirNumber,elixirDocString,elixirAtomInterpolated,elixirRegex,elixirString,elixirStringDelimiter,elixirRegexDelimiter,elixirInterpolationDelimiter,elixirSigil,elixirAnonymousFunction,elixirComment
+syn region elixirArguments start="(" end=")" contained contains=elixirOperator,elixirAtom,elixirPseudoVariable,elixirAlias,elixirBoolean,elixirVariable,elixirUnusedVariable,elixirNumber,elixirDocString,elixirAtomInterpolated,elixirRegex,elixirString,elixirStringDelimiter,elixirRegexDelimiter,elixirInterpolationDelimiter,elixirSigil,elixirAnonymousFunction,elixirComment,elixirCharList,elixirCharListDelimiter
 
 syn match elixirDelimEscape "\\[(<{\[)>}\]/\"'|]" transparent display contained contains=NONE
 
@@ -230,10 +230,12 @@ hi def link elixirRegexCharClass             elixirSpecial
 hi def link elixirRegexQuantifier            elixirSpecial
 hi def link elixirSpecial                    Special
 hi def link elixirString                     String
+hi def link elixirCharList                   Identifier
 hi def link elixirSigil                      String
 hi def link elixirDocStringDelimiter         elixirStringDelimiter
 hi def link elixirDocSigilDelimiter          elixirSigilDelimiter
 hi def link elixirStringDelimiter            Delimiter
+hi def link elixirCharListDelimiter          Identifier
 hi def link elixirRegexDelimiter             Delimiter
 hi def link elixirInterpolationDelimiter     Delimiter
 hi def link elixirSigilDelimiter             Delimiter

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -230,12 +230,12 @@ hi def link elixirRegexCharClass             elixirSpecial
 hi def link elixirRegexQuantifier            elixirSpecial
 hi def link elixirSpecial                    Special
 hi def link elixirString                     String
-hi def link elixirCharList                   Identifier
+hi def link elixirCharList                   String
 hi def link elixirSigil                      String
 hi def link elixirDocStringDelimiter         elixirStringDelimiter
 hi def link elixirDocSigilDelimiter          elixirSigilDelimiter
 hi def link elixirStringDelimiter            Delimiter
-hi def link elixirCharListDelimiter          Identifier
+hi def link elixirCharListDelimiter          Delimiter
 hi def link elixirRegexDelimiter             Delimiter
 hi def link elixirInterpolationDelimiter     Delimiter
 hi def link elixirSigilDelimiter             Delimiter

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -76,7 +76,7 @@ syn region elixirStruct matchgroup=elixirStructDelimiter start="%\(\w\+{\)\@=" e
 
 syn region elixirMap matchgroup=elixirMapDelimiter start="%{" end="}" contains=ALLBUT,@elixirNotTop fold
 
-syn region elixirCharList  matchgroup=elixirCharListDelimiter start=+\z('\)+   end=+\z1+ skip=+\\\\\|\\\z1+  contains=@Spell
+syn region elixirCharList  matchgroup=elixirCharListDelimiter start=+\z('\)+   end=+\z1+ skip=+\\\\\|\\\z1+  contains=@Spell,@elixirStringContained
 syn region elixirString  matchgroup=elixirStringDelimiter start=+\z("\)+   end=+\z1+ skip=+\\\\\|\\\z1+  contains=@Spell,@elixirStringContained
 syn region elixirString  matchgroup=elixirStringDelimiter start=+\z('''\)+ end=+^\s*\z1+ contains=@Spell,@elixirStringContained
 syn region elixirString  matchgroup=elixirStringDelimiter start=+\z("""\)+ end=+^\s*\z1+ contains=@Spell,@elixirStringContained


### PR DESCRIPTION
I believe that strings and charlists deserve different highlighting group, since those are very different data types.
Even if it is defaulted to regular vim string, it would make a little easier for us to customize our own colors.

**The motivation behind this** is that I ran into a bug when I was pattern matching the wrong value because I didn't notice I wrote single quoted "strings" instead of double quoted strings by mistake, and different colors for them would have saved me some minutes and a couple of head scratches.

I made this change today and I'm not sure they are 100% safe and did not break anything. I do not excel in those syntax groups of vim, but it seems to be working.
Comments and changes to my piece of code are more than welcome, and if this change is not what we want/need, then we can close this pull request.

Thanks for reading and providing us with this good content! (:

fixes #545 