### PR TITLE
Remove no affect replace

### DIFF
--- a/autoload/elixir/util.vim
+++ b/autoload/elixir/util.vim
@@ -15,9 +15,7 @@ function! elixir#util#get_filename(word) abort
 
   " convert to snake_case
   let word = substitute(word,'\(\u\+\)\(\u\l\)','\1_\2','g')
-  let word = substitute(word,'\(\u\+\)\(\u\l\)','\1_\2','g')
   let word = substitute(word,'\(\l\|\d\)\(\u\)','\1_\2','g')
-  let word = substitute(word,'-','_','g')
   let word = tolower(word)
 
   return word


### PR DESCRIPTION
this codes from https://github.com/tpope/vim-abolish/blob/master/plugin/abolish.vim#L120-L127

```viml
    let word = substitute(word,'\(\u\+\)\(\u\l\)','\1_\2','g')
```

line was duplicated.

```viml
    let word = substitute(word,'-','_','g')
```

elixir modules dose not allows kebab-case module name so we do not need it.