### PR TITLE
Add *.lexs to ftdetect for Temple templates

### DIFF
--- a/ftdetect/elixir.vim
+++ b/ftdetect/elixir.vim
@@ -1,5 +1,5 @@
 au BufRead,BufNewFile *.ex,*.exs set filetype=elixir
-au BufRead,BufNewFile *.eex,*.heex,*.leex,*.sface,.lexs set filetype=eelixir
+au BufRead,BufNewFile *.eex,*.heex,*.leex,*.sface,*.lexs set filetype=eelixir
 au BufRead,BufNewFile mix.lock set filetype=elixir
 au BufRead,BufNewFile * call s:DetectElixir()
 

--- a/ftdetect/elixir.vim
+++ b/ftdetect/elixir.vim
@@ -1,5 +1,5 @@
 au BufRead,BufNewFile *.ex,*.exs set filetype=elixir
-au BufRead,BufNewFile *.eex,*.leex,*.sface set filetype=eelixir
+au BufRead,BufNewFile *.eex,*.leex,*.sface,*.lexs set filetype=eelixir
 au BufRead,BufNewFile mix.lock set filetype=elixir
 au BufRead,BufNewFile * call s:DetectElixir()
 


### PR DESCRIPTION
Adds support for [Temple](https://github.com/mhanberg/temple) templates.

They are just elixir code, so all that is needed is to match the extra extension: `*.lexs` (`*.exs` is already covered obviously).