### PR TITLE
Heex support 

### DIFF
--- a/syntax/eelixir.vim
+++ b/syntax/eelixir.vim
@@ -1,5 +1,5 @@
 if exists("b:current_syntax")
-  finish
+  " finish
 endif
 
 let s:cpo_save = &cpo
@@ -59,6 +59,8 @@ syn cluster eelixirRegions contains=eelixirBlock,surfaceExpression,eelixirExpres
 exe 'syn region  eelixirExpression matchgroup=eelixirDelimiter start="<%"  end="%\@<!%>" contains=@elixirTop  containedin=ALLBUT,@eelixirRegions keepend'
 exe 'syn region  eelixirExpression matchgroup=eelixirDelimiter start="<%=" end="%\@<!%>" contains=@elixirTop  containedin=ALLBUT,@eelixirRegions keepend'
 exe 'syn region  surfaceExpression matchgroup=surfaceDelimiter start="{{" end="}}" contains=@elixirTop  containedin=ALLBUT,@eelixirRegions keepend'
+exe 'syn region  surfaceExpression matchgroup=surfaceDelimiter start="{" end="}" contains=@elixirTop  containedin=ALLBUT,@eelixirRegions keepend'
+exe 'syn region  surfaceExpression matchgroup=surfaceDelimiter start="{" end="}" skip="#{[^}]*}" contains=@elixirTop  containedin=htmlValue keepend'
 exe 'syn region  eelixirQuote      matchgroup=eelixirDelimiter start="<%%" end="%\@<!%>" contains=@elixirTop  containedin=ALLBUT,@eelixirRegions keepend'
 exe 'syn region  eelixirComment    matchgroup=eelixirDelimiter start="<%#" end="%\@<!%>" contains=elixirTodo,@Spell containedin=ALLBUT,@eelixirRegions keepend'
 

--- a/syntax/eelixir.vim
+++ b/syntax/eelixir.vim
@@ -1,5 +1,5 @@
 if exists("b:current_syntax")
-  " finish
+  finish
 endif
 
 let s:cpo_save = &cpo


### PR DESCRIPTION
Add support for heex (single curly braces) `<div id={@id}>` , skip interpolation strings inside Heex expressions.
Address :point_down: https://github.com/elixir-editors/vim-elixir/issues/555

Before: 
![image](https://user-images.githubusercontent.com/4960589/141473857-87518a23-67fe-40b5-83bb-edea3b916fb1.png)

After:
![image](https://user-images.githubusercontent.com/4960589/141473749-5dae25e9-2102-4a0a-bfed-e728ee483f93.png)
