### PR TITLE
Remove ftdetect

### DIFF
--- a/ftdetect/elixir.vim
+++ b/ftdetect/elixir.vim
@@ -1,6 +1,4 @@
-au BufRead,BufNewFile *.ex,*.exs set filetype=elixir
-au BufRead,BufNewFile *.eex,*.heex,*.leex,*.sface,*.lexs set filetype=eelixir
-au BufRead,BufNewFile mix.lock set filetype=elixir
+au BufRead,BufNewFile *.lexs set filetype=elixir "File extension used by https://github.com/mhanberg/temple
 au BufRead,BufNewFile * call s:DetectElixir()
 
 function! s:DetectElixir()


### PR DESCRIPTION
Elixir and all of the most popular template syntaxes
(LEEx, HEEx, Surface) are included in Vim and Neovim's native filetype
detection and now longer have to provided by a plugin.

I noticed the FileType event was being emitted twice when opening Elixir
files, which was causing me some problems. This should fix that.

This also switches the .lexs extension for eelixir to elixir, as that
those files are have elixir in them, not eelixir.
