### PR TITLE
Improve embedded HEEx and Surface syntax highlighting

### DIFF
--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -109,15 +109,41 @@ syn region elixirSigil matchgroup=elixirSigilDelimiter start="\~\l\/"           
 syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z("""\)+ end=+^\s*\z1+ skip=+\\"+ fold
 syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z('''\)+ end=+^\s*\z1+ skip=+\\'+ fold
 
-
-" LiveView Sigils surrounded with ~L"""
+" LiveView-specific sigils for embedded templates
 syntax include @HTML syntax/html.vim
 unlet b:current_syntax
-syntax region elixirLiveViewSigil matchgroup=elixirSigilDelimiter keepend start=+\~L\z("""\)+ end=+^\s*\z1+ skip=+\\"+ contains=@HTML fold
-syntax region elixirSurfaceSigil matchgroup=elixirSigilDelimiter keepend start=+\~H\z("""\)+ end=+^\s*\z1+ skip=+\\"+ contains=@HTML fold
+syntax region elixirHeexSigil matchgroup=elixirSigilDelimiter keepend start=+\~H\z("""\)+ end=+^\s*\z1+ skip=+\\"+ contains=@HTML fold
 syntax region elixirSurfaceSigil matchgroup=elixirSigilDelimiter keepend start=+\~F\z("""\)+ end=+^\s*\z1+ skip=+\\"+ contains=@HTML fold
+syntax region elixirLiveViewSigil matchgroup=elixirSigilDelimiter keepend start=+\~L\z("""\)+ end=+^\s*\z1+ skip=+\\"+ contains=@HTML fold
 syntax region elixirPhoenixESigil matchgroup=elixirSigilDelimiter keepend start=+\~E\z("""\)+ end=+^\s*\z1+ skip=+\\"+ contains=@HTML fold
 syntax region elixirPhoenixeSigil matchgroup=elixirSigilDelimiter keepend start=+\~e\z("""\)+ end=+^\s*\z1+ skip=+\\"+ contains=@HTML fold
+
+syn cluster elixirTemplateSigils contains=elixirLiveViewSigil,elixirHeexSigil,elixirSurfaceSigil,elixirPhoenixESigil,elixirPhoenixeSigil
+
+syn region heexComponent matchgroup=eelixirDelimiter start="<\.[a-z_]\+"  end="%\@<!>" contains=ALLBUT,@elixirNotTop keepend
+syn region eelixirExpression matchgroup=eelixirDelimiter start="<%"  end="%\@<!%>" contains=ALLBUT,@elixirNotTop containedin=@elixirTemplateSigils keepend
+syn region eelixirExpression matchgroup=eelixirDelimiter start="<%=" end="%\@<!%>" contains=ALLBUT,@elixirNotTop containedin=@elixirTemplateSigils keepend
+syn region eelixirQuote matchgroup=eelixirDelimiter start="<%%" end="%\@<!%>" contains=ALLBUT,@elixirNotTop containedin=@elixirTemplateSigils keepend
+syn region heexComment matchgroup=eelixirDelimiter start="<%!--" end="%\@<!--%>" contains=elixirTodo,eelixirComment,@Spell containedin=@elixirTemplateSigils keepend
+syn region heexExpression matchgroup=heexDelimiter start="=\zs{" end="}" contains=ALLBUT,@elixirNotTop containedin=htmlValue keepend
+syn region heexExpression matchgroup=heexDelimiter start="=\zs{" end="}" skip="#{[^}]*}" contains=ALLBUT,@elixirNotTop containedin=htmlValue keepend
+" missing `keepend` on next line is intentional
+syn region heexExpression matchgroup=heexDelimiter start="=\zs{" end="}" skip="%{[^}]*}" contains=ALLBUT,@elixirNotTop containedin=htmlValue
+
+syn match phxArg "\<phx[-.0-9_a-z]*-[-.0-9_a-z]*\>" containedin=htmlTag
+syn match heexArg "\<[0-9_a-z]*\>\ze=" containedin=htmlTag
+syn match heexSpecialAttribute ":\%(if\|for\|let\)\ze=" containedin=htmlTag
+syn match heexComponentName "<\zs\.[A-Z_a-z][A-Z_a-z0-9]\+" containedin=htmlTag
+syn match heexEndComponent "<\zs\/\.[A-Z_a-z][A-Z_a-z0-9]\+" containedin=htmlEndTag
+
+hi def link eelixirDelimiter PreProc
+hi def link heexDelimiter PreProc
+hi def link heexComment Comment
+hi def link phxArg htmlArg
+hi def link heexArg htmlArg
+hi def link heexSpecialAttribute htmlArg
+hi def link heexComponentName htmlTagName
+hi def link heexEndComponent htmlTagName
 
 " Documentation
 if exists('g:elixir_use_markdown_for_docs') && g:elixir_use_markdown_for_docs


### PR DESCRIPTION
Currently, embedded HEEx is simply highlighted as HTML.  This breaks as soon as you have lines like `:for={i <- @numbers}` or `:if={a > 2}` where the `<` and `>` are treated as HTML.  There are also other random things like `{[` that completely break highlighting.  I've been just silently dealing with this for four years now and figured I'd fix it anyway I could!

I saw the problem was mainly that you end up with a recursion error when you have `syntax/elixir.vim` calling `syn import @EELIXIR syntax/eelixir.vim` and `syntax/eelixir.vim` calling `syn import @elixirTop syntax/elixir.vim`.  After trying trying to hack around this, I figured duplication was the best answer and it's worked quite nicely.

This PR does this following:

* Properly highlight embedded HEEx (and Surface)
* Re-name groups to favour HEEx naming (this would break any customizations people have done)
* Add highlight group for `phx-` attributes
* Add highlight group for heex attribute (eg, `some_attr="some value"`)
* Add highlight group for heex special attribute (ie, `:if`, `:for`, and `:let`)

I have not copied this stuff over to `syntax/eelixir.vim` as I wanted a review first.  I can certainly roll back any of the breaking change stuff, but I don't know how many Elixirists still use vanilla Vim.

Thanks!

Closes #566