### PR TITLE
Add `g:loaded_elixir`

### DIFF
--- a/plugin/elixir.vim
+++ b/plugin/elixir.vim
@@ -1,0 +1,4 @@
+if exists("g:loaded_elixir")
+  finish
+endif
+let g:loaded_elixir = 1


### PR DESCRIPTION
This is a very simple commit that adds and checks `g:loaded_elixir`.

I'm developing a plugin that partially depends on this one and I have found no other reliable way to detect this plugin has been loaded.  I've added it to `plugin/` so that it is set at load time as opposed to autoload time to avoid load order bugs.

Thanks!