### PR TITLE
Update HEEx comment syntax

### DIFF
--- a/ftplugin/eelixir.vim
+++ b/ftplugin/eelixir.vim
@@ -108,8 +108,8 @@ if !exists('b:surround_5')
   let b:surround_5 = "<% \r %>\n<% end %>"
 endif
 
-setlocal comments=:<%#
-setlocal commentstring=<%#\ %s\ %>
+setlocal comments=:<%!--
+setlocal commentstring=<%!--\ %s\ --%>
 
 let b:undo_ftplugin = "setl cms< " .
       \ " | unlet! b:browsefilter b:match_words | " . s:undo_ftplugin

--- a/syntax/eelixir.vim
+++ b/syntax/eelixir.vim
@@ -62,7 +62,7 @@ exe 'syn region  surfaceExpression matchgroup=surfaceDelimiter start="{{" end="}
 exe 'syn region  surfaceExpression matchgroup=surfaceDelimiter start="{" end="}" contains=@elixirTop  containedin=ALLBUT,@eelixirRegions keepend'
 exe 'syn region  surfaceExpression matchgroup=surfaceDelimiter start="{" end="}" skip="#{[^}]*}" contains=@elixirTop  containedin=htmlValue keepend'
 exe 'syn region  eelixirQuote      matchgroup=eelixirDelimiter start="<%%" end="%\@<!%>" contains=@elixirTop  containedin=ALLBUT,@eelixirRegions keepend'
-exe 'syn region  eelixirComment    matchgroup=eelixirDelimiter start="<%#" end="%\@<!%>" contains=elixirTodo,@Spell containedin=ALLBUT,@eelixirRegions keepend'
+exe 'syn region  eelixirComment    matchgroup=eelixirDelimiter start="<%!--" end="%\@<!--%>"'
 
 " Define the default highlighting.
 

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -126,7 +126,7 @@ syn region heexComponent matchgroup=eelixirDelimiter start="<\.[a-z_]\+"  end="%
 syn region eelixirExpression matchgroup=eelixirDelimiter start="<%"  end="%\@<!%>" contains=ALLBUT,@elixirNotTop containedin=@elixirTemplateSigils keepend
 syn region eelixirExpression matchgroup=eelixirDelimiter start="<%=" end="%\@<!%>" contains=ALLBUT,@elixirNotTop containedin=@elixirTemplateSigils keepend
 syn region eelixirQuote matchgroup=eelixirDelimiter start="<%%" end="%\@<!%>" contains=ALLBUT,@elixirNotTop containedin=@elixirTemplateSigils keepend
-syn region heexComment matchgroup=eelixirDelimiter start="<%!--" end="%\@<!--%>" contains=elixirTodo,eelixirComment,@Spell containedin=@elixirTemplateSigils keepend
+syn region heexComment matchgroup=eelixirDelimiter start="<%!--"ms=s-1 end="%\@<!--%>"me=e+1 containedin=@HTML,@elixirTemplateSigils keepend
 syn region heexExpression matchgroup=heexDelimiter start="=\zs{" end="}" contains=ALLBUT,@elixirNotTop containedin=htmlValue keepend
 syn region heexExpression matchgroup=heexDelimiter start="=\zs{" end="}" skip="#{[^}]*}" contains=ALLBUT,@elixirNotTop containedin=htmlValue keepend
 " missing `keepend` on next line is intentional


### PR DESCRIPTION
This commit prefers the present-day comment syntax for HEEx files.

Looking for a lil' code review here if anyone is up for it otherwise I will merge in a few days.

It's not perfect mainly in that when commenting out a tag like `<a>` which has its own highlighting, the comment highlighting will be off unless the whole tag is commented out.  Similarly, commenting inside `<script>` and `<style>` get no special handling.  No errors are shown, though, which makes it a nice step up from status-quo.