### PR TITLE
Fix block start pattern

### DIFF
--- a/autoload/elixir/indent.vim
+++ b/autoload/elixir/indent.vim
@@ -379,7 +379,7 @@ endfunction
 " function, etc... so we need to first figure out what the innermost structure
 " is then forward execution to the proper handler
 function! elixir#indent#handle_inside_block(context)
-  let start_pattern = '\C\%(\<with\>\|\<if\>\|\<case\>\|\<cond\>\|\<try\>\|\<receive\>\|\<fn\>\|\<quote\>\|{\|\[\|(\)'
+  let start_pattern = '\C\%(\<with\>\|\<if\>\|\<case\>\|\<cond\>\|\<try\>\|\<receive\>\|\<fn\>\|\<quote\>\|{\|\[\|(\):\@!'
   let end_pattern = '\C\%(\<end\>\|\]\|}\|)\)'
   " hack - handle do: better
   let block_info = searchpairpos(start_pattern, '', end_pattern, 'bnW', "line('.') == " . line('.') . " || elixir#indent#searchpair_back_skip() || getline(line('.')) =~ 'do:'", max([0, a:context.lnum - g:elixir_indent_max_lookbehind]))


### PR DESCRIPTION
Hey,

Thanks for maintaining great support for Vim!

This PR fixes a somewhat annoying indentation issue that surfaced with:

```elixir
Wallaby.Browser.fill_in(some_input_box, with: "some text")
```

The regex pattern used to discover a block when it spotted a `with`. This lead to the following code:

```elixir
defmodule Broken do
  def test do
    f(:arg1, with: :arg2)
  end # ...when we hit Enter/Return here...
end
```

Being improperly indented:

```elixir
defmodule Broken do
  def test do
    f(:arg1, with: :arg2)
      end
end
```

The more `with`s, the merrier:

```elixir
defmodule Broken do
  def test do
    f(:arg1, with: :arg2)
    |> g(with: :arg3)
  end

      def test2 do # with 2 `with`s this line got indented like this

  end
end
```

This commit uses a negative lookahead to make sure the block start pattern only matches if the keyword is not immediately followed by a `:` colon character.
